### PR TITLE
(feat) Add OpenAI Codex subscription auth support

### DIFF
--- a/src/kiss/agents/vscode/commands.py
+++ b/src/kiss/agents/vscode/commands.py
@@ -279,6 +279,27 @@ class _CommandsMixin:
         new_cfg = load_config()
         self.printer.broadcast({"type": "configData", "config": new_cfg})
 
+    def _cmd_codex_auth(self, cmd: dict[str, Any]) -> None:
+        """Handle OpenAI Codex subscription auth actions."""
+        from kiss.agents.vscode.vscode_config import (
+            cancel_codex_login,
+            get_codex_auth_status,
+            logout_codex,
+            start_codex_login,
+        )
+
+        action = str(cmd.get("action", "refresh")).strip()
+        model_name = str(cmd.get("model", "")).strip()
+        if action == "login":
+            result = start_codex_login(model_name)
+        elif action == "cancelLogin":
+            result = cancel_codex_login(model_name)
+        elif action == "logout":
+            result = logout_codex(model_name)
+        else:
+            result = {"status": "ok", "auth": get_codex_auth_status(model_name)}
+        self.printer.broadcast({"type": "codexAuth", **result})
+
     def _cmd_set_skip_merge(self, cmd: dict[str, Any]) -> None:
         """Set the skip_merge flag on a tab.
 
@@ -315,4 +336,5 @@ class _CommandsMixin:
         "setSkipMerge": _cmd_set_skip_merge,
         "getConfig": _cmd_get_config,
         "saveConfig": _cmd_save_config,
+        "codexAuth": _cmd_codex_auth,
     }

--- a/src/kiss/agents/vscode/media/main.css
+++ b/src/kiss/agents/vscode/media/main.css
@@ -187,6 +187,15 @@ body {
 .config-checkbox { display: flex; align-items: center; gap: 8px; flex-direction: row; }
 .config-checkbox input[type="checkbox"] { margin: 0; width: auto; }
 .config-divider { border-top: 1px solid var(--border); margin: 12px 0; }
+.config-auth-status {
+  margin-top: 4px;
+  padding: 6px 8px;
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--fg);
+  line-height: 1.35;
+}
 
 .config-save-btn {
   display: block; width: 100%; padding: 8px; margin-top: 8px;

--- a/src/kiss/agents/vscode/media/main.css
+++ b/src/kiss/agents/vscode/media/main.css
@@ -202,6 +202,10 @@ body {
   background: var(--accent); color: #fff; border: none; border-radius: 4px;
   cursor: pointer; font-size: var(--fs-sm); font-weight: 600;
 }
+.config-save-btn[hidden] { display: none; }
+.config-save-btn.danger {
+  background: #b23b3b;
+}
 .config-save-btn:hover { opacity: 0.9; }
 
 #tab-list::-webkit-scrollbar { display: none; }

--- a/src/kiss/agents/vscode/media/main.js
+++ b/src/kiss/agents/vscode/media/main.js
@@ -16,6 +16,7 @@
   let isRunning = false;
   let selectedModel = 'claude-opus-4-6';
   let allModels = [];
+  let lastCodexAuth = null;
   let modelDDIdx = -1;
   let attachments = [];
   let _scrollLock = false;
@@ -652,6 +653,9 @@
   );
   const configSidebarClose = document.getElementById('config-sidebar-close');
   const cfgSaveBtn = document.getElementById('cfg-save-btn');
+  const cfgCodexAuthStatus = document.getElementById('cfg-codex-auth-status');
+  const cfgCodexLoginBtn = document.getElementById('cfg-codex-login-btn');
+  const cfgCodexRefreshBtn = document.getElementById('cfg-codex-refresh-btn');
   const autocommitBtn = document.getElementById('autocommit-btn');
   const waitSpinner = document.getElementById('wait-spinner');
   const ghostOverlay = document.getElementById('ghost-overlay');
@@ -1884,6 +1888,10 @@
         break;
       case 'configData':
         populateConfigForm(ev.config || {}, ev.apiKeys || {});
+        requestCodexAuth('refresh');
+        break;
+      case 'codexAuth':
+        handleCodexAuthEvent(ev);
         break;
       case 'history':
         renderHistory(ev.sessions || [], ev.offset || 0, ev.generation || 0);
@@ -3174,6 +3182,16 @@
       vscode.postMessage({type: 'saveConfig', ...data});
       closeConfigSidebar();
     });
+    if (cfgCodexLoginBtn) {
+      cfgCodexLoginBtn.addEventListener('click', () => {
+        requestCodexAuth('login');
+      });
+    }
+    if (cfgCodexRefreshBtn) {
+      cfgCodexRefreshBtn.addEventListener('click', () => {
+        requestCodexAuth('refresh');
+      });
+    }
     historySearch.addEventListener('input', () => {
       resetHistoryPagination();
       vscode.postMessage({
@@ -3730,6 +3748,7 @@
     configSidebar.classList.add('open');
     configSidebarOverlay.classList.add('open');
     configBtn.classList.add('open');
+    requestCodexAuth('refresh');
   }
   function closeConfigSidebar() {
     configSidebar.classList.remove('open');
@@ -3755,6 +3774,50 @@
     keyIds.forEach(k => {
       el('cfg-key-' + k).value = (apiKeys && apiKeys[k]) || '';
     });
+    renderCodexAuth(lastCodexAuth);
+  }
+
+  function requestCodexAuth(action) {
+    vscode.postMessage({
+      type: 'codexAuth',
+      action: action || 'refresh',
+      model: selectedModel,
+    });
+  }
+
+  function renderCodexAuth(auth) {
+    if (!cfgCodexAuthStatus) return;
+    if (!auth) {
+      cfgCodexAuthStatus.textContent = 'Checking Codex subscription status...';
+      return;
+    }
+    const bits = [];
+    if (auth.codex_auth_available) {
+      bits.push('Logged in');
+      if (auth.codex_account_id) bits.push(auth.codex_account_id);
+      bits.push('transport: ' + (auth.codex_transport || 'auto'));
+    } else {
+      bits.push('Not logged in');
+    }
+    if (auth.preferred_auth) bits.push('auth: ' + auth.preferred_auth);
+    if (auth.login_pending) bits.push('login pending');
+    if (auth.login_error) bits.push('error: ' + auth.login_error);
+    cfgCodexAuthStatus.textContent = bits.join(' · ');
+  }
+
+  function handleCodexAuthEvent(ev) {
+    lastCodexAuth = ev.auth || lastCodexAuth;
+    renderCodexAuth(lastCodexAuth);
+    if (ev.status === 'error' && ev.error) {
+      addLine('Error: ' + ev.error, true);
+    }
+    if (ev.login_url) {
+      try {
+        window.open(ev.login_url, '_blank', 'noopener');
+      } catch (_) {
+        cfgCodexAuthStatus.textContent = ev.login_url;
+      }
+    }
   }
   function collectConfigForm() {
     const el = id => document.getElementById(id);

--- a/src/kiss/agents/vscode/media/main.js
+++ b/src/kiss/agents/vscode/media/main.js
@@ -655,6 +655,7 @@
   const cfgSaveBtn = document.getElementById('cfg-save-btn');
   const cfgCodexAuthStatus = document.getElementById('cfg-codex-auth-status');
   const cfgCodexLoginBtn = document.getElementById('cfg-codex-login-btn');
+  const cfgCodexLogoutBtn = document.getElementById('cfg-codex-logout-btn');
   const cfgCodexRefreshBtn = document.getElementById('cfg-codex-refresh-btn');
   const autocommitBtn = document.getElementById('autocommit-btn');
   const waitSpinner = document.getElementById('wait-spinner');
@@ -3187,6 +3188,11 @@
         requestCodexAuth('login');
       });
     }
+    if (cfgCodexLogoutBtn) {
+      cfgCodexLogoutBtn.addEventListener('click', () => {
+        requestCodexAuth('logout');
+      });
+    }
     if (cfgCodexRefreshBtn) {
       cfgCodexRefreshBtn.addEventListener('click', () => {
         requestCodexAuth('refresh');
@@ -3596,13 +3602,16 @@
       'div',
       'model-item' + (m.name === selectedModel ? ' active' : ''),
     );
-    const price = '$' + m.inp.toFixed(2) + ' / $' + m.out.toFixed(2);
+    const showPrice = m.vendor !== 'OpenAI Codex subscription';
+    const price =
+      showPrice && Number.isFinite(m.inp) && Number.isFinite(m.out)
+        ? '$' + m.inp.toFixed(2) + ' / $' + m.out.toFixed(2)
+        : '';
     d.innerHTML =
       '<span>' +
       esc(m.name) +
-      '</span><span class="model-cost">' +
-      price +
-      '</span>';
+      '</span>' +
+      (price ? '<span class="model-cost">' + price + '</span>' : '');
     d.addEventListener('click', () => {
       selectModel(m.name);
     });
@@ -3781,7 +3790,6 @@
     vscode.postMessage({
       type: 'codexAuth',
       action: action || 'refresh',
-      model: selectedModel,
     });
   }
 
@@ -3789,20 +3797,32 @@
     if (!cfgCodexAuthStatus) return;
     if (!auth) {
       cfgCodexAuthStatus.textContent = 'Checking Codex subscription status...';
+      if (cfgCodexLoginBtn) cfgCodexLoginBtn.hidden = false;
+      if (cfgCodexLogoutBtn) cfgCodexLogoutBtn.hidden = true;
       return;
     }
-    const bits = [];
+    const loggedIn = Boolean(auth.codex_auth_available);
     if (auth.codex_auth_available) {
-      bits.push('Logged in');
-      if (auth.codex_account_id) bits.push(auth.codex_account_id);
-      bits.push('transport: ' + (auth.codex_transport || 'auto'));
-    } else {
-      bits.push('Not logged in');
+      cfgCodexAuthStatus.textContent = 'Logged in.';
+      if (cfgCodexLoginBtn) cfgCodexLoginBtn.hidden = true;
+      if (cfgCodexLogoutBtn) cfgCodexLogoutBtn.hidden = false;
+      return;
     }
-    if (auth.preferred_auth) bits.push('auth: ' + auth.preferred_auth);
-    if (auth.login_pending) bits.push('login pending');
-    if (auth.login_error) bits.push('error: ' + auth.login_error);
+    const bits = ['Not logged in'];
+    if (auth.login_pending) {
+      bits.push('login pending');
+    }
+    if (auth.login_error) {
+      bits.push('error: ' + auth.login_error);
+    }
+    if (auth.preferred_auth) {
+      bits.push('auth: ' + auth.preferred_auth);
+    } else {
+      bits.push('auth: none');
+    }
     cfgCodexAuthStatus.textContent = bits.join(' · ');
+    if (cfgCodexLoginBtn) cfgCodexLoginBtn.hidden = loggedIn || Boolean(auth.login_pending);
+    if (cfgCodexLogoutBtn) cfgCodexLogoutBtn.hidden = !loggedIn;
   }
 
   function handleCodexAuthEvent(ev) {

--- a/src/kiss/agents/vscode/server.py
+++ b/src/kiss/agents/vscode/server.py
@@ -46,7 +46,10 @@ from kiss.agents.vscode.merge_flow import _MergeFlowMixin
 from kiss.agents.vscode.printer import VSCodePrinter
 from kiss.agents.vscode.tab_state import _TabState, parse_task_tags
 from kiss.agents.vscode.task_runner import _TaskRunnerMixin
+from kiss.core import config as config_module
+from kiss.core.models import model_info
 from kiss.core.models.model_info import MODEL_INFO, get_available_models, get_default_model
+from kiss.core.models.openai_auth_routing import codex_subscription_model_sort_order
 
 __all__ = [
     "VSCodePrinter",
@@ -57,6 +60,20 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
+
+
+def _model_dropdown_vendor(name: str) -> tuple[str, float]:
+    if model_info._is_openai_family_model(name):
+        auth_mode = model_info._resolve_openai_auth_mode(
+            name,
+            config_module.DEFAULT_CONFIG.OPENAI_API_KEY,
+        )
+        if auth_mode == "codex":
+            return "OpenAI Codex subscription", 1.0
+        return "OpenAI API", 1.1
+
+    vendor_name, vendor_order = model_vendor(name)
+    return vendor_name, float(vendor_order)
 
 
 class VSCodeServer(
@@ -157,11 +174,11 @@ class VSCodeServer(
         """Send available models list with usage counts and pricing."""
         usage = _load_model_usage()
         models_list: list[dict[str, Any]] = []
-        sort_keys: dict[str, tuple[int, float]] = {}
+        sort_keys: dict[str, tuple[float, float]] = {}
         for name in get_available_models():
             info = MODEL_INFO.get(name)
             if info and info.is_function_calling_supported:
-                vendor_name, vendor_order = model_vendor(name)
+                vendor_name, vendor_order = _model_dropdown_vendor(name)
                 models_list.append({
                     "name": name,
                     "inp": info.input_price_per_1M,
@@ -170,7 +187,13 @@ class VSCodeServer(
                     "vendor": vendor_name,
                 })
                 price = float(info.input_price_per_1M) + float(info.output_price_per_1M)
-                sort_keys[name] = (vendor_order, -price)
+                if vendor_name == "OpenAI Codex subscription":
+                    sort_keys[name] = (
+                        vendor_order,
+                        float(codex_subscription_model_sort_order(name)),
+                    )
+                else:
+                    sort_keys[name] = (vendor_order, -price)
         models_list.sort(key=lambda m: sort_keys[m["name"]])
 
         # Add custom endpoint model if configured

--- a/src/kiss/agents/vscode/src/DependencyInstaller.ts
+++ b/src/kiss/agents/vscode/src/DependencyInstaller.ts
@@ -78,7 +78,7 @@ export function getDefaultModel(): string {
   if (process.env.OPENROUTER_API_KEY)
     return 'openrouter/anthropic/claude-opus-4.6';
   if (process.env.GEMINI_API_KEY) return 'gemini-3.1-pro-preview';
-  if (process.env.OPENAI_API_KEY) return 'gpt-5.4';
+  if (process.env.OPENAI_API_KEY) return 'gpt-5.5';
   if (process.env.TOGETHER_API_KEY)
     return 'Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8';
   return 'claude-opus-4-6';

--- a/src/kiss/agents/vscode/src/SorcarSidebarView.ts
+++ b/src/kiss/agents/vscode/src/SorcarSidebarView.ts
@@ -993,6 +993,14 @@ export class SorcarSidebarView implements vscode.WebviewViewProvider {
         });
         break;
 
+      case 'codexAuth':
+        this._getServiceProcess().sendCommand({
+          type: 'codexAuth',
+          action: message.action,
+          model: message.model,
+        });
+        break;
+
       case 'resolveDroppedPaths': {
         const workDir = this._getWorkDir();
         const paths = (message.uris || [])

--- a/src/kiss/agents/vscode/src/SorcarTab.ts
+++ b/src/kiss/agents/vscode/src/SorcarTab.ts
@@ -222,6 +222,12 @@ export function buildChatHtml(
           <label class="config-label">OpenAI API Key
             <input type="password" id="cfg-key-OPENAI_API_KEY" placeholder="Enter OpenAI API key">
           </label>
+          <div class="config-label">
+            <span>OpenAI Codex subscription</span>
+            <div id="cfg-codex-auth-status" class="config-auth-status">Checking...</div>
+            <button type="button" id="cfg-codex-login-btn" class="config-save-btn">Log in with OpenAI</button>
+            <button type="button" id="cfg-codex-refresh-btn" class="config-save-btn">Refresh Codex status</button>
+          </div>
           <label class="config-label">Anthropic API Key
             <input type="password" id="cfg-key-ANTHROPIC_API_KEY" placeholder="Enter Anthropic API key">
           </label>

--- a/src/kiss/agents/vscode/src/SorcarTab.ts
+++ b/src/kiss/agents/vscode/src/SorcarTab.ts
@@ -226,6 +226,7 @@ export function buildChatHtml(
             <span>OpenAI Codex subscription</span>
             <div id="cfg-codex-auth-status" class="config-auth-status">Checking...</div>
             <button type="button" id="cfg-codex-login-btn" class="config-save-btn">Log in with OpenAI</button>
+            <button type="button" id="cfg-codex-logout-btn" class="config-save-btn danger" hidden>Log out</button>
             <button type="button" id="cfg-codex-refresh-btn" class="config-save-btn">Refresh Codex status</button>
           </div>
           <label class="config-label">Anthropic API Key

--- a/src/kiss/agents/vscode/src/types.ts
+++ b/src/kiss/agents/vscode/src/types.ts
@@ -146,6 +146,13 @@ type ToWebviewMessageBody =
       apiKeys?: Record<string, string>;
     }
   | {
+      type: 'codexAuth';
+      status?: string;
+      error?: string;
+      login_url?: string;
+      auth?: Record<string, unknown>;
+    }
+  | {
       type: 'history';
       sessions: SessionInfo[];
       offset?: number;
@@ -224,7 +231,8 @@ export interface AgentCommand {
     | 'getAdjacentTask'
     | 'setSkipMerge'
     | 'getConfig'
-    | 'saveConfig';
+    | 'saveConfig'
+    | 'codexAuth';
   prompt?: string;
   model?: string;
   workDir?: string;
@@ -238,7 +246,16 @@ export interface AgentCommand {
   path?: string;
   chatId?: number | string;
   activeFileContent?: string;
-  action?: 'merge' | 'discard' | 'all-done' | 'commit' | 'skip';
+  action?:
+    | 'merge'
+    | 'discard'
+    | 'all-done'
+    | 'commit'
+    | 'skip'
+    | 'login'
+    | 'refresh'
+    | 'logout'
+    | 'cancelLogin';
   useWorktree?: boolean;
   useParallel?: boolean;
   task?: string;

--- a/src/kiss/agents/vscode/src/types.ts
+++ b/src/kiss/agents/vscode/src/types.ts
@@ -75,6 +75,11 @@ export type FromWebviewMessage =
       type: 'saveConfig';
       config: Record<string, unknown>;
       apiKeys: Record<string, string>;
+    }
+  | {
+      type: 'codexAuth';
+      action: 'login' | 'refresh' | 'logout' | 'cancelLogin';
+      model?: string;
     };
 
 /** Messages from extension to webview (matches browser event protocol) */

--- a/src/kiss/agents/vscode/vscode_config.py
+++ b/src/kiss/agents/vscode/vscode_config.py
@@ -18,6 +18,8 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
 
+from kiss.core.models.openai_auth_routing import CODEX_AUTH_DISABLED_FILE
+
 logger = logging.getLogger(__name__)
 
 CONFIG_DIR = Path.home() / ".kiss"
@@ -25,6 +27,7 @@ CONFIG_PATH = CONFIG_DIR / "config.json"
 _oauth_lock = threading.Lock()
 _oauth_pending: dict[str, Any] | None = None
 _oauth_last_error = ""
+_oauth_completed_states: set[str] = set()
 _oauth_callback_server: ThreadingHTTPServer | None = None
 _oauth_callback_thread: threading.Thread | None = None
 
@@ -271,6 +274,17 @@ def _clear_codex_auth_caches() -> None:
         logger.debug("Failed to clear Codex auth caches", exc_info=True)
 
 
+def _set_codex_auth_disabled(disabled: bool) -> None:
+    try:
+        if disabled:
+            CODEX_AUTH_DISABLED_FILE.parent.mkdir(parents=True, exist_ok=True)
+            CODEX_AUTH_DISABLED_FILE.write_text(str(time.time()), encoding="utf-8")
+        elif CODEX_AUTH_DISABLED_FILE.exists():
+            CODEX_AUTH_DISABLED_FILE.unlink()
+    except OSError:
+        logger.debug("Failed to update Codex auth disabled marker", exc_info=True)
+
+
 def _mask_auth_id(value: str | None) -> str:
     if not value:
         return ""
@@ -284,7 +298,7 @@ def get_codex_auth_status(model_name: str = "") -> dict[str, Any]:
     from kiss.core import config as config_module
     from kiss.core.models import model_info
 
-    requested_model = model_name or "gpt-5.5"
+    requested_model = model_name or "gpt-5.4"
     is_openai_model = model_info._is_openai_family_model(requested_model)
     preferred_auth = model_info._resolve_openai_auth_mode(
         requested_model,
@@ -378,10 +392,24 @@ def _ensure_oauth_callback_server() -> tuple[bool, str]:
                     _oauth_last_error = error
                     status_code = 400
                     message = f"OpenAI Codex login failed: {error}"
-                elif not pending or state != pending.get("state"):
-                    _oauth_last_error = "OAuth state mismatch."
-                    status_code = 400
-                    message = "OpenAI Codex login failed: OAuth state mismatch."
+                elif not pending:
+                    if state and state in _oauth_completed_states:
+                        _oauth_last_error = ""
+                    else:
+                        _oauth_last_error = "OAuth callback did not match an active login."
+                        status_code = 400
+                        message = (
+                            "OpenAI Codex login failed: callback did not match "
+                            "an active login."
+                        )
+                elif state != pending.get("state"):
+                    if OpenAICodexOAuthManager().has_credentials():
+                        _oauth_last_error = ""
+                        message = "OpenAI Codex login already completed. You can close this window."
+                    else:
+                        _oauth_last_error = "OAuth state mismatch."
+                        status_code = 400
+                        message = "OpenAI Codex login failed: OAuth state mismatch."
                 elif time.time() > float(pending.get("expires_at", 0)):
                     _oauth_last_error = "OAuth login expired."
                     status_code = 400
@@ -392,9 +420,13 @@ def _ensure_oauth_callback_server() -> tuple[bool, str]:
                     message = "OpenAI Codex login failed: missing code."
                 else:
                     verifier = str(pending.get("code_verifier", ""))
+                    pending_state = str(pending.get("state", ""))
                     token = OpenAICodexOAuthManager().exchange_authorization_code(code, verifier)
                     if token:
                         _oauth_pending = None
+                        if pending_state:
+                            _oauth_completed_states.add(pending_state)
+                        _set_codex_auth_disabled(False)
                         _oauth_last_error = ""
                         _clear_codex_auth_caches()
                     else:
@@ -495,9 +527,11 @@ def logout_codex(model_name: str = "") -> dict[str, Any]:
         manager = OpenAICodexOAuthManager()
         if manager.cache_file.exists():
             manager.cache_file.unlink()
+        manager._credentials = None
     except OSError:
         logger.debug("Failed to remove Codex OAuth cache", exc_info=True)
     except Exception:
         logger.debug("Failed to initialize Codex OAuth manager", exc_info=True)
+    _set_codex_auth_disabled(True)
     _clear_codex_auth_caches()
     return {"status": "ok", "auth": get_codex_auth_status(model_name)}

--- a/src/kiss/agents/vscode/vscode_config.py
+++ b/src/kiss/agents/vscode/vscode_config.py
@@ -10,6 +10,11 @@ import json
 import logging
 import os
 import subprocess
+import threading
+import time
+import urllib.parse
+import webbrowser
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +22,11 @@ logger = logging.getLogger(__name__)
 
 CONFIG_DIR = Path.home() / ".kiss"
 CONFIG_PATH = CONFIG_DIR / "config.json"
+_oauth_lock = threading.Lock()
+_oauth_pending: dict[str, Any] | None = None
+_oauth_last_error = ""
+_oauth_callback_server: ThreadingHTTPServer | None = None
+_oauth_callback_thread: threading.Thread | None = None
 
 DEFAULTS: dict[str, Any] = {
     "max_budget": 100,
@@ -249,3 +259,245 @@ def source_shell_env() -> None:
     except (subprocess.TimeoutExpired, OSError):
         logger.debug("Failed to source shell env", exc_info=True)
     _refresh_config()
+
+
+def _clear_codex_auth_caches() -> None:
+    try:
+        from kiss.core.models import model_info
+
+        model_info._is_codex_cli_auth_available.cache_clear()
+        model_info._is_codex_native_auth_available.cache_clear()
+    except Exception:
+        logger.debug("Failed to clear Codex auth caches", exc_info=True)
+
+
+def _mask_auth_id(value: str | None) -> str:
+    if not value:
+        return ""
+    if len(value) <= 8:
+        return value
+    return f"{value[:4]}...{value[-4:]}"
+
+
+def get_codex_auth_status(model_name: str = "") -> dict[str, Any]:
+    """Return OpenAI/Codex subscription auth status for the config UI."""
+    from kiss.core import config as config_module
+    from kiss.core.models import model_info
+
+    requested_model = model_name or "gpt-5.5"
+    is_openai_model = model_info._is_openai_family_model(requested_model)
+    preferred_auth = model_info._resolve_openai_auth_mode(
+        requested_model,
+        config_module.DEFAULT_CONFIG.OPENAI_API_KEY,
+    )
+    codex_account_id = ""
+    codex_cache_file = ""
+    codex_source_file = ""
+    try:
+        from kiss.core.models.codex_oauth import (
+            CODEX_OAUTH_CALLBACK_PORT,
+            OpenAICodexOAuthManager,
+        )
+
+        manager = OpenAICodexOAuthManager()
+        codex_account_id = manager.get_account_id() or ""
+        codex_cache_file = str(manager.cache_file)
+        codex_source_file = str(manager.source_file)
+        callback_port = CODEX_OAUTH_CALLBACK_PORT
+    except Exception:
+        callback_port = 1455
+
+    with _oauth_lock:
+        login_pending = _oauth_pending is not None
+        login_error = _oauth_last_error
+
+    return {
+        "model": requested_model,
+        "is_openai_model": is_openai_model,
+        "preferred_auth": preferred_auth,
+        "codex_subscription_model": model_info._is_codex_subscription_model(requested_model),
+        "openai_api_key_configured": bool(config_module.DEFAULT_CONFIG.OPENAI_API_KEY),
+        "codex_auth_available": model_info._is_codex_auth_available(),
+        "codex_native_available": model_info._is_codex_native_auth_available(),
+        "codex_cli_available": model_info._is_codex_cli_auth_available(),
+        "codex_transport": model_info._resolve_codex_transport(),
+        "login_pending": login_pending,
+        "login_error": login_error,
+        "oauth_callback_port": callback_port,
+        "forced_auth": os.environ.get("KISS_OPENAI_AUTH", "").strip().lower() or "auto",
+        "forced_transport": os.environ.get("KISS_CODEX_TRANSPORT", "").strip().lower() or "auto",
+        "codex_account_id": _mask_auth_id(codex_account_id),
+        "codex_cache_file": codex_cache_file,
+        "codex_source_file": codex_source_file,
+    }
+
+
+def _shutdown_oauth_callback_server() -> None:
+    global _oauth_callback_server, _oauth_callback_thread
+    server = _oauth_callback_server
+    _oauth_callback_server = None
+    _oauth_callback_thread = None
+    if server is not None:
+        try:
+            server.shutdown()
+            server.server_close()
+        except OSError:
+            logger.debug("Failed to stop Codex OAuth callback server", exc_info=True)
+
+
+def _ensure_oauth_callback_server() -> tuple[bool, str]:
+    global _oauth_callback_server, _oauth_callback_thread, _oauth_pending, _oauth_last_error
+    if _oauth_callback_server is not None:
+        return True, ""
+
+    try:
+        from kiss.core.models.codex_oauth import (
+            CODEX_OAUTH_CALLBACK_PORT,
+            OpenAICodexOAuthManager,
+        )
+    except ImportError as exc:
+        return False, str(exc)
+
+    class _OAuthCallbackHandler(BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: Any) -> None:
+            return
+
+        def do_GET(self) -> None:
+            global _oauth_pending, _oauth_last_error
+            parsed = urllib.parse.urlparse(self.path)
+            params = urllib.parse.parse_qs(parsed.query)
+            code = params.get("code", [""])[0]
+            state = params.get("state", [""])[0]
+            error = params.get("error", [""])[0]
+
+            status_code = 200
+            message = "OpenAI Codex login completed. You can close this window."
+            with _oauth_lock:
+                pending = _oauth_pending
+                if error:
+                    _oauth_last_error = error
+                    status_code = 400
+                    message = f"OpenAI Codex login failed: {error}"
+                elif not pending or state != pending.get("state"):
+                    _oauth_last_error = "OAuth state mismatch."
+                    status_code = 400
+                    message = "OpenAI Codex login failed: OAuth state mismatch."
+                elif time.time() > float(pending.get("expires_at", 0)):
+                    _oauth_last_error = "OAuth login expired."
+                    status_code = 400
+                    message = "OpenAI Codex login failed: login expired."
+                elif not code:
+                    _oauth_last_error = "OAuth callback did not include a code."
+                    status_code = 400
+                    message = "OpenAI Codex login failed: missing code."
+                else:
+                    verifier = str(pending.get("code_verifier", ""))
+                    token = OpenAICodexOAuthManager().exchange_authorization_code(code, verifier)
+                    if token:
+                        _oauth_pending = None
+                        _oauth_last_error = ""
+                        _clear_codex_auth_caches()
+                    else:
+                        _oauth_last_error = "Token exchange failed."
+                        status_code = 400
+                        message = "OpenAI Codex login failed: token exchange failed."
+
+            body = (
+                "<!doctype html><html><body>"
+                f"<p>{message}</p>"
+                "</body></html>"
+            ).encode()
+            self.send_response(status_code)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    try:
+        server = ThreadingHTTPServer(
+            ("127.0.0.1", CODEX_OAUTH_CALLBACK_PORT),
+            _OAuthCallbackHandler,
+        )
+    except OSError as exc:
+        return False, str(exc)
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    _oauth_callback_server = server
+    _oauth_callback_thread = thread
+    return True, ""
+
+
+def start_codex_login(model_name: str = "") -> dict[str, Any]:
+    """Start OpenAI Codex OAuth login and return a browser URL."""
+    global _oauth_pending, _oauth_last_error
+    try:
+        from kiss.core.models.codex_oauth import (
+            CODEX_OAUTH_REDIRECT_URI,
+            build_authorization_url,
+            generate_code_challenge,
+            generate_code_verifier,
+            generate_oauth_state,
+        )
+    except ImportError as exc:
+        return {"status": "error", "error": str(exc), "auth": get_codex_auth_status(model_name)}
+
+    verifier = generate_code_verifier()
+    state = generate_oauth_state()
+    login_url = build_authorization_url(
+        generate_code_challenge(verifier),
+        state,
+        originator="kiss-ai",
+        redirect_uri=CODEX_OAUTH_REDIRECT_URI,
+    )
+    with _oauth_lock:
+        _oauth_pending = {
+            "state": state,
+            "code_verifier": verifier,
+            "created_at": time.time(),
+            "expires_at": time.time() + 300.0,
+        }
+        _oauth_last_error = ""
+
+    started, error = _ensure_oauth_callback_server()
+    if not started:
+        with _oauth_lock:
+            _oauth_pending = None
+            _oauth_last_error = error
+        return {"status": "error", "error": error, "auth": get_codex_auth_status(model_name)}
+
+    try:
+        webbrowser.open(login_url)
+    except Exception:
+        logger.debug("Failed to open Codex OAuth URL", exc_info=True)
+    return {
+        "status": "ok",
+        "login_url": login_url,
+        "auth": get_codex_auth_status(model_name),
+    }
+
+
+def cancel_codex_login(model_name: str = "") -> dict[str, Any]:
+    """Cancel a pending OpenAI Codex OAuth login."""
+    global _oauth_pending, _oauth_last_error
+    with _oauth_lock:
+        _oauth_pending = None
+        _oauth_last_error = ""
+    _shutdown_oauth_callback_server()
+    return {"status": "ok", "auth": get_codex_auth_status(model_name)}
+
+
+def logout_codex(model_name: str = "") -> dict[str, Any]:
+    """Remove KISS-managed Codex OAuth cache and refresh auth status."""
+    try:
+        from kiss.core.models.codex_oauth import OpenAICodexOAuthManager
+
+        manager = OpenAICodexOAuthManager()
+        if manager.cache_file.exists():
+            manager.cache_file.unlink()
+    except OSError:
+        logger.debug("Failed to remove Codex OAuth cache", exc_info=True)
+    except Exception:
+        logger.debug("Failed to initialize Codex OAuth manager", exc_info=True)
+    _clear_codex_auth_caches()
+    return {"status": "ok", "auth": get_codex_auth_status(model_name)}

--- a/src/kiss/agents/vscode/web_server.py
+++ b/src/kiss/agents/vscode/web_server.py
@@ -821,6 +821,9 @@ a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/>
             <button type="button" id="cfg-codex-login-btn" class="config-save-btn">
               Log in with OpenAI
             </button>
+            <button type="button" id="cfg-codex-logout-btn" class="config-save-btn danger" hidden>
+              Log out
+            </button>
             <button type="button" id="cfg-codex-refresh-btn" class="config-save-btn">
               Refresh Codex status
             </button>

--- a/src/kiss/agents/vscode/web_server.py
+++ b/src/kiss/agents/vscode/web_server.py
@@ -813,11 +813,21 @@ a4 4 0 015.66 5.66l-9.2 9.19a2 2 0 01-2.83-2.83l8.49-8.48"/>
           </label>
           <label class="config-label">OpenAI API Key
             <input type="password" id="cfg-key-OPENAI_API_KEY"
-             placeholder="Enter OpenAI API key">
+                   placeholder="Enter OpenAI API key">
           </label>
+          <div class="config-label">
+            <span>OpenAI Codex subscription</span>
+            <div id="cfg-codex-auth-status" class="config-auth-status">Checking...</div>
+            <button type="button" id="cfg-codex-login-btn" class="config-save-btn">
+              Log in with OpenAI
+            </button>
+            <button type="button" id="cfg-codex-refresh-btn" class="config-save-btn">
+              Refresh Codex status
+            </button>
+          </div>
           <label class="config-label">Anthropic API Key
             <input type="password" id="cfg-key-ANTHROPIC_API_KEY"
-             placeholder="Enter Anthropic API key">
+                   placeholder="Enter Anthropic API key">
           </label>
           <label class="config-label">Together API Key
             <input type="password" id="cfg-key-TOGETHER_API_KEY"

--- a/src/kiss/core/models/__init__.py
+++ b/src/kiss/core/models/__init__.py
@@ -12,6 +12,8 @@ __all__ = [
     "Model",
     "AnthropicModel",
     "ClaudeCodeModel",
+    "CodexCliModel",
+    "CodexNativeModel",
     "OpenAICompatibleModel",
     "GeminiModel",
 ]
@@ -19,6 +21,8 @@ __all__ = [
 _LAZY_IMPORTS = {
     "AnthropicModel": "kiss.core.models.anthropic_model",
     "ClaudeCodeModel": "kiss.core.models.claude_code_model",
+    "CodexCliModel": "kiss.core.models.codex_cli_model",
+    "CodexNativeModel": "kiss.core.models.codex_native_model",
     "OpenAICompatibleModel": "kiss.core.models.openai_compatible_model",
     "GeminiModel": "kiss.core.models.gemini_model",
 }

--- a/src/kiss/core/models/codex_cli_model.py
+++ b/src/kiss/core/models/codex_cli_model.py
@@ -1,0 +1,385 @@
+# Author: Koushik Sen (ksen@berkeley.edu)
+# Contributors:
+# Koushik Sen (ksen@berkeley.edu)
+# add your name here
+
+"""Codex CLI-backed model implementation.
+
+This adapter enables running OpenAI-family models through the local `codex`
+CLI authentication flow (for example "Logged in using ChatGPT"), without
+requiring OPENAI_API_KEY.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import mimetypes
+import re
+import shutil
+import subprocess
+import tempfile
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from kiss.core.kiss_error import KISSError
+from kiss.core.models.model import Attachment, Model, ThinkingCallback, TokenCallback
+
+
+def _build_text_based_tools_prompt(function_map: dict[str, Callable[..., Any]]) -> str:
+    """Build a text-based tools description for Codex CLI prompting."""
+    if not function_map:
+        return ""
+
+    tools_desc: list[str] = []
+    for func_name, func in function_map.items():
+        sig = inspect.signature(func)
+        doc = inspect.getdoc(func) or f"Function {func_name}"
+
+        params: list[str] = []
+        for param_name, param in sig.parameters.items():
+            param_type = param.annotation
+            type_name = getattr(param_type, "__name__", str(param_type))
+            if type_name == "_empty":
+                type_name = "any"
+            params.append(f"    - {param_name} ({type_name})")
+
+        params_str = "\n".join(params) if params else "    (no parameters)"
+        first_line = doc.split(chr(10))[0]
+        tools_desc.append(f"- **{func_name}**: {first_line}\n  Parameters:\n{params_str}")
+
+    return f"""
+## Available Tools
+
+To call a tool, output a JSON object in the following format:
+
+```json
+{{"tool_calls": [{{"name": "tool_name", "arguments": {{"arg1": "value1", "arg2": "value2"}}}}]}}
+```
+
+You can call multiple tools at once by including multiple objects in the tool_calls array.
+
+### Tools:
+{chr(10).join(tools_desc)}
+
+IMPORTANT: When you want to call a tool, output ONLY the JSON object with tool_calls.
+Do not include any other text before or after the JSON.
+When you have the final answer, call the `finish` tool with your result.
+"""
+
+
+def _parse_text_based_tool_calls(content: str) -> list[dict[str, Any]]:
+    """Parse tool calls from text output."""
+    function_calls: list[dict[str, Any]] = []
+
+    json_patterns = [
+        r"```json\s*(\{.*?\})\s*```",
+        r"```\s*(\{.*?\})\s*```",
+        r"(\{[^{}]*\"tool_calls\"[^{}]*\[[^\]]*\][^{}]*\})",
+    ]
+
+    for pattern in json_patterns:
+        matches = re.findall(pattern, content, re.DOTALL)
+        for match in matches:
+            try:
+                data = json.loads(match)
+                if "tool_calls" in data and isinstance(data["tool_calls"], list):
+                    for tc in data["tool_calls"]:
+                        if "name" in tc:
+                            function_calls.append(
+                                {
+                                    "id": f"call_{uuid.uuid4().hex[:8]}",
+                                    "name": tc["name"],
+                                    "arguments": tc.get("arguments", {}),
+                                }
+                            )
+                    if function_calls:
+                        return function_calls
+            except json.JSONDecodeError:
+                continue
+
+    try:
+        data = json.loads(content.strip())
+        if "tool_calls" in data and isinstance(data["tool_calls"], list):
+            for tc in data["tool_calls"]:
+                if "name" in tc:
+                    function_calls.append(
+                        {
+                            "id": f"call_{uuid.uuid4().hex[:8]}",
+                            "name": tc["name"],
+                            "arguments": tc.get("arguments", {}),
+                        }
+                    )
+    except json.JSONDecodeError:
+        pass
+
+    return function_calls
+
+
+class CodexCliModel(Model):
+    """Model adapter that delegates generation to `codex exec --json`."""
+
+    def __init__(
+        self,
+        model_name: str,
+        model_config: dict[str, Any] | None = None,
+        token_callback: TokenCallback | None = None,
+        thinking_callback: ThinkingCallback | None = None,
+    ) -> None:
+        super().__init__(
+            model_name,
+            model_config=model_config,
+            token_callback=token_callback,
+            thinking_callback=thinking_callback,
+        )
+        self.codex_path = shutil.which("codex")
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}(name={self.model_name})"
+
+    __repr__ = __str__
+
+    def initialize(self, prompt: str, attachments: list[Attachment] | None = None) -> None:
+        if not self.codex_path:
+            raise KISSError(
+                "Codex CLI not found in PATH. Install Codex CLI and run `codex login` first."
+            )
+        self.conversation = []
+        system_instruction = self.model_config.get("system_instruction")
+        if system_instruction:
+            self.conversation.append({"role": "system", "content": system_instruction})
+        self.conversation.append(
+            {
+                "role": "user",
+                "content": prompt,
+                "attachments": list(attachments or []),
+            }
+        )
+
+    @staticmethod
+    def _collect_usage(stdout: str) -> dict[str, int]:
+        usage: dict[str, int] = {}
+        for line in stdout.splitlines():
+            text = line.strip()
+            if not text.startswith("{"):
+                continue
+            try:
+                event = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            if event.get("type") == "turn.completed" and isinstance(event.get("usage"), dict):
+                raw_usage = event["usage"]
+                usage = {
+                    "input_tokens": int(raw_usage.get("input_tokens", 0) or 0),
+                    "cached_input_tokens": int(raw_usage.get("cached_input_tokens", 0) or 0),
+                    "output_tokens": int(raw_usage.get("output_tokens", 0) or 0),
+                }
+        return usage
+
+    @staticmethod
+    def _collect_last_agent_message(stdout: str) -> str:
+        last_text = ""
+        for line in stdout.splitlines():
+            text = line.strip()
+            if not text.startswith("{"):
+                continue
+            try:
+                event = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            if event.get("type") != "item.completed":
+                continue
+            item = event.get("item")
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") == "agent_message":
+                maybe_text = item.get("text")
+                if isinstance(maybe_text, str):
+                    last_text = maybe_text
+        return last_text
+
+    @staticmethod
+    def _attachment_suffix(mime_type: str) -> str:
+        ext = mimetypes.guess_extension(mime_type) or ""
+        return ext if ext else ".bin"
+
+    def _latest_image_attachments(self) -> list[Attachment]:
+        for msg in reversed(self.conversation):
+            if msg.get("role") != "user":
+                continue
+            attachments = msg.get("attachments")
+            if isinstance(attachments, list) and attachments:
+                images = [
+                    a
+                    for a in attachments
+                    if isinstance(a, Attachment) and a.mime_type.startswith("image/")
+                ]
+                non_images = [
+                    a
+                    for a in attachments
+                    if isinstance(a, Attachment) and not a.mime_type.startswith("image/")
+                ]
+                if non_images:
+                    raise KISSError("Codex CLI model currently supports image attachments only.")
+                return images
+        return []
+
+    def _conversation_for_prompt(self) -> list[dict[str, Any]]:
+        rendered: list[dict[str, Any]] = []
+        for msg in self.conversation:
+            role = str(msg.get("role", "user"))
+            entry: dict[str, Any] = {"role": role, "content": str(msg.get("content", ""))}
+            tool_calls = msg.get("tool_calls")
+            if isinstance(tool_calls, list) and tool_calls:
+                entry["tool_calls"] = tool_calls
+            tool_call_id = msg.get("tool_call_id")
+            if isinstance(tool_call_id, str) and tool_call_id:
+                entry["tool_call_id"] = tool_call_id
+            attachments = msg.get("attachments")
+            if isinstance(attachments, list) and attachments:
+                entry["attachments"] = [
+                    a.mime_type for a in attachments if isinstance(a, Attachment)
+                ]
+            rendered.append(entry)
+        return rendered
+
+    def _build_generation_prompt(self, tools_prompt: str | None = None) -> str:
+        sections = [
+            "You are acting as a backend chat-completion model for an external orchestrator.",
+            "Return only the next assistant response as plain text.",
+            "Do not wrap the response in markdown fences.",
+        ]
+        if tools_prompt:
+            sections.append(
+                "When a tool call is needed, follow the exact JSON contract below."
+            )
+            sections.append(tools_prompt)
+        sections.append("Conversation JSON:")
+        sections.append(json.dumps(self._conversation_for_prompt(), ensure_ascii=False, indent=2))
+        return "\n\n".join(sections)
+
+    def _run_codex_exec(self, prompt: str) -> tuple[str, dict[str, Any]]:
+        if not self.codex_path:
+            raise KISSError(
+                "Codex CLI not found in PATH. Install Codex CLI and run `codex login` first."
+            )
+
+        timeout_seconds = float(self.model_config.get("timeout_seconds", 300))
+        work_dir = str(self.model_config.get("codex_work_dir", Path.cwd()))
+
+        image_paths: list[str] = []
+        temp_files: list[str] = []
+        try:
+            for att in self._latest_image_attachments():
+                suffix = self._attachment_suffix(att.mime_type)
+                with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as f:
+                    f.write(att.data)
+                    temp_files.append(f.name)
+                    image_paths.append(f.name)
+
+            cmd: list[str] = [
+                self.codex_path,
+                "exec",
+                "--sandbox",
+                "read-only",
+                "--skip-git-repo-check",
+                "--json",
+                "--model",
+                self.model_name,
+                "-C",
+                work_dir,
+            ]
+            for image_path in image_paths:
+                cmd.extend(["--image", image_path])
+            cmd.append("-")
+
+            result = subprocess.run(
+                cmd,
+                input=prompt,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                timeout=timeout_seconds,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise KISSError(f"Codex CLI timed out after {timeout_seconds:.1f}s") from e
+        except OSError as e:
+            raise KISSError(f"Failed to execute Codex CLI: {e}") from e
+        finally:
+            for path in temp_files:
+                try:
+                    Path(path).unlink(missing_ok=True)
+                except OSError:
+                    pass
+
+        if result.returncode != 0:
+            error_text = (result.stderr or result.stdout or "").strip()
+            fallback = error_text or "unknown error"
+            raise KISSError(
+                f"Codex CLI failed with exit code {result.returncode}: {fallback}"
+            )
+
+        response_text = self._collect_last_agent_message(result.stdout)
+        usage = self._collect_usage(result.stdout)
+        metadata = {"usage": usage, "stdout": result.stdout, "stderr": result.stderr}
+        return response_text, metadata
+
+    def generate(self) -> tuple[str, Any]:
+        prompt = self._build_generation_prompt()
+        content, response = self._run_codex_exec(prompt)
+        self.conversation.append({"role": "assistant", "content": content})
+        if content and self.token_callback is not None:
+            self._invoke_token_callback(content)
+        return content, response
+
+    def generate_and_process_with_tools(
+        self,
+        function_map: dict[str, Callable[..., Any]],
+        tools_schema: list[dict[str, Any]] | None = None,
+    ) -> tuple[list[dict[str, Any]], str, Any]:
+        del tools_schema
+        tools_prompt = _build_text_based_tools_prompt(function_map)
+        prompt = self._build_generation_prompt(tools_prompt)
+        content, response = self._run_codex_exec(prompt)
+        if content and self.token_callback is not None:
+            self._invoke_token_callback(content)
+
+        function_calls = _parse_text_based_tool_calls(content)
+        assistant_msg: dict[str, Any] = {"role": "assistant", "content": content}
+        if function_calls:
+            assistant_msg["tool_calls"] = [
+                {
+                    "id": fc["id"],
+                    "type": "function",
+                    "function": {
+                        "name": fc["name"],
+                        "arguments": fc.get("arguments", {}),
+                    },
+                }
+                for fc in function_calls
+            ]
+        self.conversation.append(assistant_msg)
+        return function_calls, content, response
+
+    def extract_input_output_token_counts_from_response(
+        self, response: Any
+    ) -> tuple[int, int, int, int]:
+        usage: dict[str, int] = {}
+        if isinstance(response, dict):
+            maybe_usage = response.get("usage")
+            if isinstance(maybe_usage, dict):
+                usage = maybe_usage
+        input_tokens = int(usage.get("input_tokens", 0) or 0)
+        cache_read = int(usage.get("cached_input_tokens", 0) or 0)
+        output_tokens = int(usage.get("output_tokens", 0) or 0)
+        non_cached_input = max(0, input_tokens - cache_read)
+        return non_cached_input, output_tokens, cache_read, 0
+
+    def get_embedding(self, text: str, embedding_model: str | None = None) -> list[float]:
+        model_to_use = embedding_model or self.model_name
+        raise KISSError(
+            f"Embedding generation is not supported by Codex CLI model backend ({model_to_use})."
+        )

--- a/src/kiss/core/models/codex_native_model.py
+++ b/src/kiss/core/models/codex_native_model.py
@@ -1,0 +1,419 @@
+# Author: Koushik Sen (ksen@berkeley.edu)
+# Contributors:
+# Koushik Sen (ksen@berkeley.edu)
+# add your name here
+
+"""Native OpenAI Codex backend transport via /backend-api/codex/responses."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+import uuid
+from collections.abc import Callable
+from typing import Any
+
+from kiss._version import __version__
+from kiss.core.kiss_error import KISSError
+from kiss.core.models.codex_cli_model import (
+    _build_text_based_tools_prompt,
+    _parse_text_based_tool_calls,
+)
+from kiss.core.models.codex_oauth import OpenAICodexOAuthManager
+from kiss.core.models.model import Attachment, Model, ThinkingCallback, TokenCallback
+
+
+class CodexNativeModel(Model):
+    """Model adapter that calls the Codex backend directly over HTTPS."""
+
+    CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
+
+    def __init__(
+        self,
+        model_name: str,
+        model_config: dict[str, Any] | None = None,
+        token_callback: TokenCallback | None = None,
+        thinking_callback: ThinkingCallback | None = None,
+        oauth_manager: OpenAICodexOAuthManager | None = None,
+    ) -> None:
+        super().__init__(
+            model_name,
+            model_config=model_config,
+            token_callback=token_callback,
+            thinking_callback=thinking_callback,
+        )
+        self.oauth_manager = oauth_manager or OpenAICodexOAuthManager()
+        self.session_id = uuid.uuid4().hex
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}(name={self.model_name})"
+
+    __repr__ = __str__
+
+    def initialize(self, prompt: str, attachments: list[Attachment] | None = None) -> None:
+        self.conversation = []
+        system_instruction = self.model_config.get("system_instruction")
+        if system_instruction:
+            self.conversation.append({"role": "system", "content": system_instruction})
+        self.conversation.append(
+            {
+                "role": "user",
+                "content": prompt,
+                "attachments": list(attachments or []),
+            }
+        )
+
+    def _latest_image_attachments(self) -> list[Attachment]:
+        for msg in reversed(self.conversation):
+            if msg.get("role") != "user":
+                continue
+            attachments = msg.get("attachments")
+            if not isinstance(attachments, list) or not attachments:
+                continue
+            images = [
+                a
+                for a in attachments
+                if isinstance(a, Attachment) and a.mime_type.startswith("image/")
+            ]
+            non_images = [
+                a
+                for a in attachments
+                if isinstance(a, Attachment) and not a.mime_type.startswith("image/")
+            ]
+            if non_images:
+                raise KISSError("Codex native backend currently supports image attachments only.")
+            return images
+        return []
+
+    def _conversation_for_prompt(self) -> list[dict[str, Any]]:
+        rendered: list[dict[str, Any]] = []
+        for msg in self.conversation:
+            role = str(msg.get("role", "user"))
+            entry: dict[str, Any] = {"role": role, "content": str(msg.get("content", ""))}
+            tool_calls = msg.get("tool_calls")
+            if isinstance(tool_calls, list) and tool_calls:
+                entry["tool_calls"] = tool_calls
+            tool_call_id = msg.get("tool_call_id")
+            if isinstance(tool_call_id, str) and tool_call_id:
+                entry["tool_call_id"] = tool_call_id
+            attachments = msg.get("attachments")
+            if isinstance(attachments, list) and attachments:
+                entry["attachments"] = [
+                    a.mime_type for a in attachments if isinstance(a, Attachment)
+                ]
+            rendered.append(entry)
+        return rendered
+
+    def _build_generation_prompt(self, tools_prompt: str | None = None) -> str:
+        sections = [
+            "You are acting as a backend chat-completion model for an external orchestrator.",
+            "Return only the next assistant response as plain text.",
+            "Do not wrap the response in markdown fences.",
+        ]
+        if tools_prompt:
+            sections.append("When a tool call is needed, follow the exact JSON contract below.")
+            sections.append(tools_prompt)
+        sections.append("Conversation JSON:")
+        sections.append(json.dumps(self._conversation_for_prompt(), ensure_ascii=False, indent=2))
+        return "\n\n".join(sections)
+
+    @staticmethod
+    def _extract_text_from_response_body(body: dict[str, Any]) -> str:
+        output_text = body.get("output_text")
+        if isinstance(output_text, str) and output_text:
+            return output_text
+
+        output = body.get("output")
+        if not isinstance(output, list):
+            return ""
+        chunks: list[str] = []
+        for item in output:
+            if not isinstance(item, dict):
+                continue
+            item_type = item.get("type")
+            if item_type == "message":
+                content = item.get("content")
+                if isinstance(content, list):
+                    for part in content:
+                        if not isinstance(part, dict):
+                            continue
+                        if part.get("type") in {"output_text", "text"}:
+                            text = part.get("text")
+                            if isinstance(text, str) and text:
+                                chunks.append(text)
+            elif item_type == "text":
+                text = item.get("text")
+                if isinstance(text, str) and text:
+                    chunks.append(text)
+        return "".join(chunks)
+
+    @staticmethod
+    def _normalize_usage(body: dict[str, Any]) -> dict[str, int]:
+        usage_raw = body.get("usage")
+        if not isinstance(usage_raw, dict):
+            return {}
+
+        input_details = usage_raw.get("input_tokens_details")
+        if not isinstance(input_details, dict):
+            input_details = usage_raw.get("prompt_tokens_details")
+        if not isinstance(input_details, dict):
+            input_details = {}
+
+        input_tokens = usage_raw.get("input_tokens", usage_raw.get("prompt_tokens", 0))
+        if not isinstance(input_tokens, (int, float)):
+            input_tokens = 0
+
+        cached = usage_raw.get("cache_read_input_tokens")
+        if not isinstance(cached, (int, float)):
+            cached = usage_raw.get("cache_read_tokens")
+        if not isinstance(cached, (int, float)):
+            cached = usage_raw.get("cached_tokens")
+        if not isinstance(cached, (int, float)):
+            cached = input_details.get("cached_tokens", 0)
+        if not isinstance(cached, (int, float)):
+            cached = 0
+
+        output_tokens = usage_raw.get("output_tokens", usage_raw.get("completion_tokens", 0))
+        if not isinstance(output_tokens, (int, float)):
+            output_tokens = 0
+
+        return {
+            "input_tokens": int(input_tokens),
+            "cached_input_tokens": int(cached),
+            "output_tokens": int(output_tokens),
+        }
+
+    def _build_request_body(self, prompt: str) -> dict[str, Any]:
+        content: list[dict[str, str]] = [{"type": "input_text", "text": prompt}]
+        for att in self._latest_image_attachments():
+            content.append({"type": "input_image", "image_url": att.to_data_url()})
+
+        instructions = self.model_config.get("codex_instructions")
+        if not isinstance(instructions, str) or not instructions.strip():
+            instructions = self.model_config.get("system_instruction")
+        if not isinstance(instructions, str) or not instructions.strip():
+            instructions = "You are a backend assistant for an external orchestrator."
+
+        body: dict[str, Any] = {
+            "model": self.model_name,
+            "input": [{"role": "user", "content": content}],
+            "instructions": instructions,
+            "stream": True,
+            "store": False,
+        }
+        reasoning_effort = self.model_config.get("reasoning_effort")
+        if isinstance(reasoning_effort, str) and reasoning_effort:
+            body["reasoning"] = {"effort": reasoning_effort, "summary": "auto"}
+            body["include"] = ["reasoning.encrypted_content"]
+        return body
+
+    def _request_headers(self, access_token: str) -> dict[str, str]:
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {access_token}",
+            "originator": "kiss-ai",
+            "session_id": self.session_id,
+            "User-Agent": f"kiss-ai/{__version__}",
+        }
+        account_id = self.oauth_manager.get_account_id()
+        if account_id:
+            headers["ChatGPT-Account-Id"] = account_id
+        return headers
+
+    def _default_timeout_seconds(self) -> float:
+        """Return transport timeout tuned by Codex model tier."""
+        return 20.0 if "spark" in self.model_name else 90.0
+
+    def _post_responses_request(self, body: dict[str, Any]) -> dict[str, Any]:
+        access_token = self.oauth_manager.get_access_token()
+        if not access_token:
+            raise KISSError(
+                "Codex OAuth credentials are unavailable. Run `codex login` or set "
+                "KISS_CODEX_AUTH_FILE to a valid auth.json."
+            )
+
+        timeout_seconds = float(
+            self.model_config.get("timeout_seconds", self._default_timeout_seconds())
+        )
+        body_bytes = json.dumps(body).encode("utf-8")
+
+        for attempt in range(2):
+            request = urllib.request.Request(
+                self.CODEX_RESPONSES_URL,
+                data=body_bytes,
+                headers=self._request_headers(access_token),
+                method="POST",
+            )
+            try:
+                with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+                    return self._parse_sse_response(response)
+            except urllib.error.HTTPError as exc:
+                err_body = exc.read().decode("utf-8", errors="replace").strip()
+                auth_error = exc.code in {401, 403}
+                if attempt == 0 and auth_error:
+                    refreshed = self.oauth_manager.force_refresh_access_token()
+                    if refreshed:
+                        access_token = refreshed
+                        continue
+                raise KISSError(
+                    f"Codex native API failed with status {exc.code}: {err_body or exc.reason}"
+                ) from exc
+            except urllib.error.URLError as exc:
+                raise KISSError(f"Codex native API request failed: {exc.reason}") from exc
+
+        raise KISSError("Codex native API request failed after token refresh retry.")
+
+    def _parse_sse_response(self, response: Any) -> dict[str, Any]:
+        content_parts: list[str] = []
+        usage: dict[str, int] = {}
+        completed_response: dict[str, Any] = {}
+        early_tool_exit = bool(self.model_config.get("early_tool_exit", True))
+
+        for raw_line in response:
+            line = raw_line.decode("utf-8", errors="replace").strip()
+            if not line or line.startswith(":"):
+                continue
+            if not line.startswith("data:"):
+                continue
+            payload = line[5:].strip()
+            if payload == "[DONE]":
+                break
+            try:
+                event = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
+                continue
+
+            event_type = event.get("type")
+            if event_type in {"response.text.delta", "response.output_text.delta"}:
+                delta = event.get("delta")
+                if isinstance(delta, str) and delta:
+                    content_parts.append(delta)
+                    if early_tool_exit:
+                        candidate = "".join(content_parts)
+                        if _parse_text_based_tool_calls(candidate):
+                            return {
+                                "output_text": candidate,
+                                "usage": usage,
+                                "response": completed_response,
+                            }
+                continue
+
+            if event_type in {"response.text.done", "response.output_text.done"}:
+                text_done = event.get("text")
+                if isinstance(text_done, str) and text_done:
+                    content_parts.append(text_done)
+                    if early_tool_exit and _parse_text_based_tool_calls(text_done):
+                        return {
+                            "output_text": text_done,
+                            "usage": usage,
+                            "response": completed_response,
+                        }
+                continue
+
+            if event_type in {"response.error", "response.failed", "error"}:
+                message = ""
+                err_obj = event.get("error")
+                if isinstance(err_obj, dict):
+                    err_msg = err_obj.get("message")
+                    if isinstance(err_msg, str):
+                        message = err_msg
+                if not message:
+                    raw_msg = event.get("message")
+                    if isinstance(raw_msg, str):
+                        message = raw_msg
+                raise KISSError(f"Codex native API stream error: {message or 'unknown error'}")
+
+            event_usage = event.get("usage")
+            if isinstance(event_usage, dict):
+                usage = self._normalize_usage({"usage": event_usage})
+
+            if event_type in {"response.done", "response.completed"}:
+                maybe_response = event.get("response")
+                if isinstance(maybe_response, dict):
+                    completed_response = maybe_response
+                    maybe_usage = maybe_response.get("usage")
+                    if isinstance(maybe_usage, dict):
+                        usage = self._normalize_usage({"usage": maybe_usage})
+
+        content = "".join(content_parts)
+        if not content and completed_response:
+            content = self._extract_text_from_response_body(
+                {
+                    "output_text": completed_response.get("output_text"),
+                    "output": completed_response.get("output"),
+                }
+            )
+
+        return {
+            "output_text": content,
+            "usage": usage,
+            "response": completed_response,
+        }
+
+    def _run_codex_request(self, prompt: str) -> tuple[str, dict[str, Any]]:
+        body = self._build_request_body(prompt)
+        response_body = self._post_responses_request(body)
+        content = self._extract_text_from_response_body(response_body)
+        usage = self._normalize_usage(response_body)
+        metadata = {"usage": usage, "response": response_body}
+        return content, metadata
+
+    def generate(self) -> tuple[str, Any]:
+        prompt = self._build_generation_prompt()
+        content, response = self._run_codex_request(prompt)
+        self.conversation.append({"role": "assistant", "content": content})
+        if content and self.token_callback is not None:
+            self._invoke_token_callback(content)
+        return content, response
+
+    def generate_and_process_with_tools(
+        self,
+        function_map: dict[str, Callable[..., Any]],
+        tools_schema: list[dict[str, Any]] | None = None,
+    ) -> tuple[list[dict[str, Any]], str, Any]:
+        del tools_schema
+        tools_prompt = _build_text_based_tools_prompt(function_map)
+        prompt = self._build_generation_prompt(tools_prompt)
+        content, response = self._run_codex_request(prompt)
+        if content and self.token_callback is not None:
+            self._invoke_token_callback(content)
+
+        function_calls = _parse_text_based_tool_calls(content)
+        assistant_msg: dict[str, Any] = {"role": "assistant", "content": content}
+        if function_calls:
+            assistant_msg["tool_calls"] = [
+                {
+                    "id": fc["id"],
+                    "type": "function",
+                    "function": {
+                        "name": fc["name"],
+                        "arguments": fc.get("arguments", {}),
+                    },
+                }
+                for fc in function_calls
+            ]
+        self.conversation.append(assistant_msg)
+        return function_calls, content, response
+
+    def extract_input_output_token_counts_from_response(
+        self, response: Any
+    ) -> tuple[int, int, int, int]:
+        usage: dict[str, int] = {}
+        if isinstance(response, dict):
+            maybe_usage = response.get("usage")
+            if isinstance(maybe_usage, dict):
+                usage = maybe_usage
+        input_tokens = int(usage.get("input_tokens", 0) or 0)
+        cache_read = int(usage.get("cached_input_tokens", 0) or 0)
+        output_tokens = int(usage.get("output_tokens", 0) or 0)
+        non_cached_input = max(0, input_tokens - cache_read)
+        return non_cached_input, output_tokens, cache_read, 0
+
+    def get_embedding(self, text: str, embedding_model: str | None = None) -> list[float]:
+        model_to_use = embedding_model or self.model_name
+        raise KISSError(
+            f"Embedding generation is not supported by Codex native backend ({model_to_use})."
+        )

--- a/src/kiss/core/models/codex_oauth.py
+++ b/src/kiss/core/models/codex_oauth.py
@@ -1,0 +1,436 @@
+# Author: Koushik Sen (ksen@berkeley.edu)
+# Contributors:
+# Koushik Sen (ksen@berkeley.edu)
+# add your name here
+
+"""Native OAuth token management for OpenAI Codex subscription auth."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+CODEX_OAUTH_TOKEN_ENDPOINT = "https://auth.openai.com/oauth/token"
+CODEX_OAUTH_AUTHORIZATION_ENDPOINT = "https://auth.openai.com/oauth/authorize"
+CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+CODEX_OAUTH_REDIRECT_URI = "http://localhost:1455/auth/callback"
+CODEX_OAUTH_SCOPES = "openid profile email offline_access"
+CODEX_OAUTH_CALLBACK_PORT = 1455
+
+
+def _decode_jwt_claims(token: str) -> dict[str, Any]:
+    """Decode JWT payload claims; return empty dict when token is malformed."""
+    parts = token.split(".")
+    if len(parts) != 3:
+        return {}
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(payload.encode("ascii"))
+        decoded = json.loads(raw.decode("utf-8"))
+        if isinstance(decoded, dict):
+            return decoded
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError):
+        return {}
+    return {}
+
+
+def generate_code_verifier() -> str:
+    """Generate a PKCE code verifier (base64url without padding)."""
+    raw = secrets.token_bytes(32)
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def generate_code_challenge(code_verifier: str) -> str:
+    """Generate S256 PKCE code challenge from verifier."""
+    digest = hashlib.sha256(code_verifier.encode("utf-8")).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii").rstrip("=")
+
+
+def generate_oauth_state() -> str:
+    """Generate random OAuth state for CSRF protection."""
+    return secrets.token_hex(16)
+
+
+def build_authorization_url(
+    code_challenge: str,
+    state: str,
+    *,
+    originator: str = "kiss-ai",
+    redirect_uri: str = CODEX_OAUTH_REDIRECT_URI,
+) -> str:
+    """Build OpenAI Codex OAuth authorization URL with PKCE."""
+    params = urllib.parse.urlencode(
+        {
+            "client_id": CODEX_OAUTH_CLIENT_ID,
+            "redirect_uri": redirect_uri,
+            "scope": CODEX_OAUTH_SCOPES,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "response_type": "code",
+            "state": state,
+            # Codex-specific flow flags used by known working implementations.
+            "codex_cli_simplified_flow": "true",
+            "originator": originator,
+        }
+    )
+    return f"{CODEX_OAUTH_AUTHORIZATION_ENDPOINT}?{params}"
+
+
+def _extract_account_id_from_claims(claims: dict[str, Any]) -> str | None:
+    """Extract ChatGPT account id from known JWT claim locations."""
+    root = claims.get("chatgpt_account_id")
+    if isinstance(root, str) and root:
+        return root
+
+    nested = claims.get("https://api.openai.com/auth")
+    if isinstance(nested, dict):
+        nested_id = nested.get("chatgpt_account_id")
+        if isinstance(nested_id, str) and nested_id:
+            return nested_id
+
+    organizations = claims.get("organizations")
+    if isinstance(organizations, list) and organizations:
+        first = organizations[0]
+        if isinstance(first, dict):
+            org_id = first.get("id")
+            if isinstance(org_id, str) and org_id:
+                return org_id
+    return None
+
+
+def _extract_expiry_timestamp(access_token: str, id_token: str | None = None) -> float | None:
+    """Extract token expiration timestamp (seconds since epoch) from JWT claims."""
+    for token in (id_token, access_token):
+        if not token:
+            continue
+        claims = _decode_jwt_claims(token)
+        exp = claims.get("exp")
+        if isinstance(exp, (int, float)):
+            return float(exp)
+    return None
+
+
+@dataclass
+class CodexOAuthCredentials:
+    access_token: str
+    refresh_token: str | None
+    id_token: str | None
+    account_id: str | None
+    expires_at: float | None
+    updated_at: float
+
+    def is_expired(self, *, buffer_seconds: int = 300) -> bool:
+        """Return True if the access token is expired (with clock-skew buffer)."""
+        if self.expires_at is None:
+            return False
+        return time.time() >= self.expires_at - buffer_seconds
+
+
+class OpenAICodexOAuthManager:
+    """Loads and refreshes OpenAI Codex OAuth credentials."""
+
+    def __init__(
+        self,
+        cache_file: str | None = None,
+        source_file: str | None = None,
+        token_endpoint: str = CODEX_OAUTH_TOKEN_ENDPOINT,
+        client_id: str = CODEX_OAUTH_CLIENT_ID,
+    ) -> None:
+        cache_default = Path("~/.kiss/codex_oauth.json").expanduser()
+        source_default = Path("~/.codex/auth.json").expanduser()
+        self.cache_file = Path(cache_file).expanduser() if cache_file else cache_default
+        self.source_file = Path(source_file).expanduser() if source_file else source_default
+        self.token_endpoint = token_endpoint
+        self.client_id = client_id
+        self._credentials: CodexOAuthCredentials | None = None
+        self._lock = threading.Lock()
+
+    def has_credentials(self) -> bool:
+        """Return True if a usable access token or refresh token is available."""
+        creds = self._load_credentials()
+        if creds is None:
+            return False
+        return bool(creds.access_token or creds.refresh_token)
+
+    def get_account_id(self) -> str | None:
+        """Return cached ChatGPT account id when available."""
+        creds = self._load_credentials()
+        return creds.account_id if creds else None
+
+    def force_refresh_access_token(self) -> str | None:
+        """Force refresh using the stored refresh token."""
+        return self.get_access_token(force_refresh=True)
+
+    def exchange_authorization_code(
+        self,
+        code: str,
+        code_verifier: str,
+        *,
+        redirect_uri: str = CODEX_OAUTH_REDIRECT_URI,
+    ) -> str | None:
+        """Exchange OAuth authorization code for tokens and persist credentials."""
+        form = urllib.parse.urlencode(
+            {
+                "grant_type": "authorization_code",
+                "client_id": self.client_id,
+                "code": code,
+                "redirect_uri": redirect_uri,
+                "code_verifier": code_verifier,
+            }
+        ).encode("utf-8")
+        request = urllib.request.Request(
+            self.token_endpoint,
+            data=form,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            method="POST",
+        )
+        timeout_seconds = float(os.environ.get("KISS_CODEX_OAUTH_TIMEOUT_SECONDS", "30"))
+        try:
+            with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+                body = response.read().decode("utf-8")
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError):
+            return None
+
+        try:
+            token_data = json.loads(body)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(token_data, dict):
+            return None
+
+        with self._lock:
+            credentials = self._credentials_from_token_response(token_data)
+            if credentials is None:
+                return None
+            self._credentials = credentials
+            self._save_credentials(credentials)
+            return credentials.access_token
+
+    def get_access_token(self, *, force_refresh: bool = False) -> str | None:
+        """Return a valid access token, refreshing when needed."""
+        with self._lock:
+            creds = self._load_credentials()
+            if creds is None:
+                return None
+            needs_refresh = force_refresh or creds.is_expired() or not creds.access_token
+            if needs_refresh:
+                refreshed = self._refresh_credentials(creds)
+                if refreshed is None:
+                    return None
+                self._credentials = refreshed
+                self._save_credentials(refreshed)
+                creds = refreshed
+            return creds.access_token
+
+    def _load_credentials(self) -> CodexOAuthCredentials | None:
+        if self._credentials is not None:
+            return self._credentials
+
+        creds = self._load_from_cache()
+        if creds is not None:
+            self._credentials = creds
+            return creds
+
+        creds = self._load_from_codex_auth_file()
+        if creds is not None:
+            self._credentials = creds
+            # Persist to KISS cache so we can refresh without mutating Codex-managed files.
+            self._save_credentials(creds)
+        return creds
+
+    def _load_from_cache(self) -> CodexOAuthCredentials | None:
+        if not self.cache_file.exists():
+            return None
+        try:
+            data = json.loads(self.cache_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        return self._credentials_from_dict(data)
+
+    def _load_from_codex_auth_file(self) -> CodexOAuthCredentials | None:
+        auth_file_env = os.environ.get("KISS_CODEX_AUTH_FILE")
+        source_file = Path(auth_file_env).expanduser() if auth_file_env else self.source_file
+        if not source_file.exists():
+            return None
+        try:
+            data = json.loads(source_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+
+        token_data: dict[str, Any] = {}
+        if isinstance(data.get("tokens"), dict):
+            token_data = dict(data["tokens"])
+        else:
+            token_data = data
+
+        creds = self._credentials_from_dict(token_data)
+        if creds is None:
+            return None
+
+        last_refresh = data.get("last_refresh")
+        if isinstance(last_refresh, str):
+            try:
+                # "2026-03-03T18:35:39.038815400Z" -> epoch seconds
+                ts = last_refresh.replace("Z", "+00:00")
+                creds.updated_at = max(creds.updated_at, _iso_to_epoch(ts))
+            except ValueError:
+                pass
+        return creds
+
+    def _credentials_from_dict(self, data: dict[str, Any]) -> CodexOAuthCredentials | None:
+        access_token = data.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            return None
+
+        refresh_token = data.get("refresh_token")
+        if not isinstance(refresh_token, str):
+            refresh_token = None
+
+        id_token = data.get("id_token")
+        if not isinstance(id_token, str):
+            id_token = None
+
+        account_id = data.get("account_id")
+        if not isinstance(account_id, str):
+            account_id = None
+        if not account_id:
+            account_id = _extract_account_id_from_claims(
+                _decode_jwt_claims(id_token or access_token)
+            )
+
+        expires_at_val = data.get("expires_at")
+        expires_at = float(expires_at_val) if isinstance(expires_at_val, (int, float)) else None
+        if expires_at is None:
+            expires_at = _extract_expiry_timestamp(access_token, id_token)
+
+        updated_at_val = data.get("updated_at")
+        updated_at = (
+            float(updated_at_val)
+            if isinstance(updated_at_val, (int, float))
+            else time.time()
+        )
+
+        return CodexOAuthCredentials(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            id_token=id_token,
+            account_id=account_id,
+            expires_at=expires_at,
+            updated_at=updated_at,
+        )
+
+    def _save_credentials(self, credentials: CodexOAuthCredentials) -> None:
+        payload = {
+            "type": "openai-codex",
+            "access_token": credentials.access_token,
+            "refresh_token": credentials.refresh_token,
+            "id_token": credentials.id_token,
+            "account_id": credentials.account_id,
+            "expires_at": credentials.expires_at,
+            "updated_at": credentials.updated_at,
+        }
+        try:
+            self.cache_file.parent.mkdir(parents=True, exist_ok=True)
+            self.cache_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        except OSError:
+            # Cache persistence failure should not break request flow.
+            return
+
+    def _refresh_credentials(
+        self, credentials: CodexOAuthCredentials
+    ) -> CodexOAuthCredentials | None:
+        if not credentials.refresh_token:
+            return None
+
+        form = urllib.parse.urlencode(
+            {
+                "grant_type": "refresh_token",
+                "client_id": self.client_id,
+                "refresh_token": credentials.refresh_token,
+            }
+        ).encode("utf-8")
+
+        request = urllib.request.Request(
+            self.token_endpoint,
+            data=form,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            method="POST",
+        )
+        timeout_seconds = float(os.environ.get("KISS_CODEX_OAUTH_TIMEOUT_SECONDS", "15"))
+
+        try:
+            with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+                body = response.read().decode("utf-8")
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError):
+            return None
+
+        try:
+            token_data = json.loads(body)
+        except json.JSONDecodeError:
+            return None
+
+        refreshed = self._credentials_from_token_response(
+            token_data,
+            fallback_refresh_token=credentials.refresh_token,
+            fallback_id_token=credentials.id_token,
+            fallback_account_id=credentials.account_id,
+        )
+        return refreshed
+
+    def _credentials_from_token_response(
+        self,
+        token_data: dict[str, Any],
+        *,
+        fallback_refresh_token: str | None = None,
+        fallback_id_token: str | None = None,
+        fallback_account_id: str | None = None,
+    ) -> CodexOAuthCredentials | None:
+        access_token = token_data.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            return None
+
+        refresh_token = token_data.get("refresh_token")
+        if not isinstance(refresh_token, str) or not refresh_token:
+            refresh_token = fallback_refresh_token
+
+        id_token = token_data.get("id_token")
+        if not isinstance(id_token, str):
+            id_token = fallback_id_token
+
+        expires_in = token_data.get("expires_in")
+        expires_at: float | None = None
+        if isinstance(expires_in, (int, float)):
+            expires_at = time.time() + float(expires_in)
+        if expires_at is None:
+            expires_at = _extract_expiry_timestamp(access_token, id_token)
+
+        account_id = _extract_account_id_from_claims(_decode_jwt_claims(id_token or access_token))
+        if not account_id:
+            account_id = fallback_account_id
+
+        return CodexOAuthCredentials(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            id_token=id_token,
+            account_id=account_id,
+            expires_at=expires_at,
+            updated_at=time.time(),
+        )
+
+
+def _iso_to_epoch(value: str) -> float:
+    from datetime import datetime
+
+    return datetime.fromisoformat(value).timestamp()

--- a/src/kiss/core/models/model_info.py
+++ b/src/kiss/core/models/model_info.py
@@ -11,6 +11,10 @@ FLAKY MODEL MARKERS:
 - Models with comments like "SLOW" may timeout on some requests
 """
 
+import os
+import shutil
+import subprocess
+from functools import lru_cache
 from typing import Any
 
 from kiss.core import config as config_module
@@ -80,7 +84,53 @@ def _emb(ctx: int, inp: float) -> ModelInfo:
     return ModelInfo(ctx, inp, 0.0, False, True, False)
 
 
-_OPENAI_PREFIXES = ("gpt", "text-embedding", "o1", "o3", "o4", "codex", "computer-use")
+_OPENAI_PREFIXES = (
+    "chatgpt",
+    "gpt",
+    "text-embedding",
+    "o1",
+    "o3",
+    "o4",
+    "codex",
+    "computer-use",
+)
+_CODEX_PROVIDER_MODELS = frozenset(
+    {
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+        "gpt-5.2-codex",
+        "gpt-5.1-codex-max",
+        "gpt-5.2",
+        "gpt-5.1-codex-mini",
+    }
+)
+_CODEX_SUBSCRIPTION_MODELS = frozenset(
+    {
+        "chatgpt-4o-latest",
+        "codex-mini-latest",
+        "computer-use-preview",
+        "gpt-5",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5-chat-latest",
+        "gpt-5-codex",
+        "gpt-5-mini",
+        "gpt-5-nano",
+        "gpt-5.1",
+        "gpt-5.1-chat-latest",
+        "gpt-5.1-codex",
+        "gpt-5.1-codex-max",
+        "gpt-5.1-codex-mini",
+        "gpt-5.2",
+        "gpt-5.2-codex",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+    }
+)
 _TOGETHER_PREFIXES = (
     "meta-llama/",
     "Qwen/",
@@ -120,6 +170,131 @@ def _openai_compatible(
         token_callback=token_callback,
         thinking_callback=thinking_callback,
     )
+
+
+def _is_openai_family_model(model_name: str) -> bool:
+    return model_name.startswith(_OPENAI_PREFIXES) and not model_name.startswith("openai/gpt-oss")
+
+
+def _is_codex_subscription_model(model_name: str) -> bool:
+    """Return True when model_name is known to be available through Codex auth."""
+    return model_name in _CODEX_SUBSCRIPTION_MODELS
+
+
+def is_codex_provider_model(model_name: str) -> bool:
+    """Return True when model_name belongs to the explicit Codex UI provider catalog."""
+    return model_name in _CODEX_PROVIDER_MODELS
+
+
+def _codex_cli(
+    model_name: str,
+    model_config: dict[str, Any] | None,
+    token_callback: TokenCallback | None,
+    thinking_callback: ThinkingCallback | None = None,
+) -> Model:
+    from kiss.core.models import CodexCliModel
+
+    if CodexCliModel is None:  # pragma: no cover - optional adapter import
+        raise KISSError("Codex CLI adapter is unavailable.")
+    return CodexCliModel(  # type: ignore[no-any-return]
+        model_name=model_name,
+        model_config=model_config,
+        token_callback=token_callback,
+        thinking_callback=thinking_callback,
+    )
+
+
+def _codex_native(
+    model_name: str,
+    model_config: dict[str, Any] | None,
+    token_callback: TokenCallback | None,
+    thinking_callback: ThinkingCallback | None = None,
+) -> Model:
+    from kiss.core.models import CodexNativeModel
+
+    if CodexNativeModel is None:  # pragma: no cover - optional adapter import
+        raise KISSError("Codex native adapter is unavailable.")
+    return CodexNativeModel(  # type: ignore[no-any-return]
+        model_name=model_name,
+        model_config=model_config,
+        token_callback=token_callback,
+        thinking_callback=thinking_callback,
+    )
+
+
+@lru_cache(maxsize=1)
+def _is_codex_cli_auth_available() -> bool:
+    """Return True when Codex CLI is installed and has an authenticated login."""
+    if os.environ.get("KISS_DISABLE_CODEX_AUTH") == "1":
+        return False
+    codex_path = shutil.which("codex")
+    if not codex_path:
+        return False
+    try:
+        result = subprocess.run(
+            [codex_path, "login", "status"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if result.returncode != 0:
+        return False
+    status_text = f"{result.stdout}\n{result.stderr}".lower()
+    return "logged in" in status_text
+
+
+@lru_cache(maxsize=1)
+def _is_codex_native_auth_available() -> bool:
+    """Return True when native Codex OAuth credentials are locally available."""
+    if os.environ.get("KISS_DISABLE_CODEX_AUTH") == "1":
+        return False
+    try:
+        from kiss.core.models.codex_oauth import OpenAICodexOAuthManager
+
+        return OpenAICodexOAuthManager().has_credentials()
+    except Exception:
+        return False
+
+
+def _is_codex_auth_available() -> bool:
+    """Return True when either native OAuth or Codex CLI auth is available."""
+    return _is_codex_native_auth_available() or _is_codex_cli_auth_available()
+
+
+def _resolve_codex_transport() -> str:
+    """Resolve Codex transport backend: native first, CLI fallback."""
+    forced = os.environ.get("KISS_CODEX_TRANSPORT", "").strip().lower()
+    if forced in {"native", "oauth", "direct"}:
+        return "native" if _is_codex_native_auth_available() else "cli"
+    if forced in {"cli", "exec", "subprocess"}:
+        return "cli"
+    if _is_codex_native_auth_available():
+        return "native"
+    return "cli"
+
+
+def _resolve_openai_auth_mode(model_name: str, openai_api_key: str) -> str:
+    """Resolve platform API key auth vs ChatGPT/Codex subscription auth."""
+    forced = os.environ.get("KISS_OPENAI_AUTH", "").strip().lower()
+    if forced in {"api", "api_key", "platform"}:
+        return "api"
+    if forced in {"codex", "subscription", "chatgpt"}:
+        if _is_codex_auth_available() and _is_codex_subscription_model(model_name):
+            return "codex"
+        return "api"
+
+    codex_auth = _is_codex_auth_available()
+    supports_codex = _is_codex_subscription_model(model_name)
+    if codex_auth and supports_codex:
+        return "codex"
+    if openai_api_key:
+        return "api"
+    if codex_auth and supports_codex:
+        return "codex"
+    return "api"
 
 
 MODEL_INFO: dict[str, ModelInfo] = {
@@ -241,6 +416,7 @@ MODEL_INFO: dict[str, ModelInfo] = {
     "gpt-5.2-pro-2025-12-11": _mi(400000, 21.00, 168.00),
     "gpt-5.3-chat-latest": _mi(400000, 1.75, 14.00),
     "gpt-5.3-codex": _mi(400000, 1.75, 14.00),
+    "gpt-5.3-codex-spark": _mi(400000, 1.75, 14.00),
     "gpt-5.4": _mi(1050000, 2.50, 15.00),
     "gpt-5.4-2026-03-05": _mi(1050000, 2.50, 15.00),
     "gpt-5.4-mini": _mi(400000, 0.75, 4.50),
@@ -732,7 +908,7 @@ def _strip_provider_prefix(model_name: str) -> str:
     """Strip harbor-style provider prefixes that duplicate KISS's own routing.
 
     Harbor (and other frameworks) pass model names as ``provider/model``
-    (e.g. ``openai/gpt-5.4``, ``anthropic/claude-opus-4-6``,
+    (e.g. ``openai/gpt-5.5``, ``anthropic/claude-opus-4-6``,
     ``google/gemini-2.5-pro``).  KISS already routes by the model name
     itself (``gpt-*`` → OpenAI, ``claude-*`` → Anthropic, etc.), so the
     provider prefix is redundant and must be stripped.
@@ -771,7 +947,7 @@ def model(
     Args:
         model_name: The name of the model (with provider prefix if applicable).
             Accepts harbor-style ``provider/model`` names (e.g.
-            ``openai/gpt-5.4``, ``anthropic/claude-opus-4-6``) — the
+            ``openai/gpt-5.5``, ``anthropic/claude-opus-4-6``) — the
             redundant provider prefix is stripped automatically.
         model_config: Optional dictionary of model configuration parameters.
             If it contains "base_url", routing is bypassed and an OpenAICompatibleModel
@@ -822,7 +998,24 @@ def model(
             model_config=model_config,
             token_callback=token_callback,
         )
-    if model_name.startswith(_OPENAI_PREFIXES) and not model_name.startswith("openai/gpt-oss"):
+    if _is_openai_family_model(model_name):
+        auth_mode = _resolve_openai_auth_mode(model_name, keys.OPENAI_API_KEY)
+        if auth_mode == "codex":
+            transport = _resolve_codex_transport()
+            if transport == "native" and _is_codex_native_auth_available():
+                return _codex_native(
+                    model_name,
+                    model_config,
+                    token_callback,
+                    thinking_callback,
+                )
+            if _is_codex_cli_auth_available():
+                return _codex_cli(
+                    model_name,
+                    model_config,
+                    token_callback,
+                    thinking_callback,
+                )
         return _openai_compatible(
             model_name,
             "https://api.openai.com/v1",
@@ -922,8 +1115,11 @@ def get_available_models() -> list[str]:
         if not api_key:
             if name == "text-embedding-004":  # pragma: no cover – embedding model filtered above
                 api_key = keys.GEMINI_API_KEY
-            elif name.startswith(_OPENAI_PREFIXES) and not name.startswith("openai/gpt-oss"):
-                api_key = keys.OPENAI_API_KEY
+            elif _is_openai_family_model(name):
+                if keys.OPENAI_API_KEY or (
+                    _is_codex_auth_available() and _is_codex_subscription_model(name)
+                ):
+                    api_key = "available"
             elif name.startswith(_TOGETHER_PREFIXES):
                 api_key = keys.TOGETHER_API_KEY
         if api_key:
@@ -945,7 +1141,9 @@ def get_default_model() -> str:
     if keys.GEMINI_API_KEY:
         return "gemini-3.1-pro-preview"
     if keys.OPENAI_API_KEY:
-        return "gpt-5.4"
+        return "gpt-5.5"
+    if _is_codex_auth_available():
+        return "gpt-5.5"
     if keys.TOGETHER_API_KEY:
         return "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8"
     return "claude-opus-4-6"

--- a/src/kiss/core/models/model_info.py
+++ b/src/kiss/core/models/model_info.py
@@ -11,15 +11,24 @@ FLAKY MODEL MARKERS:
 - Models with comments like "SLOW" may timeout on some requests
 """
 
-import os
-import shutil
-import subprocess
-from functools import lru_cache
 from typing import Any
 
 from kiss.core import config as config_module
 from kiss.core.kiss_error import KISSError
 from kiss.core.models.model import Model, ThinkingCallback, TokenCallback
+from kiss.core.models.openai_auth_routing import (
+    _OPENAI_PREFIXES,
+    _is_codex_auth_available,
+    _is_codex_cli_auth_available,
+    _is_codex_native_auth_available,
+    _is_codex_subscription_model,
+    _is_openai_family_model,
+    _resolve_codex_transport,
+    _resolve_openai_auth_mode,
+)
+from kiss.core.models.openai_auth_routing import (
+    is_codex_provider_model as is_codex_provider_model,
+)
 
 
 class ModelInfo:
@@ -84,53 +93,6 @@ def _emb(ctx: int, inp: float) -> ModelInfo:
     return ModelInfo(ctx, inp, 0.0, False, True, False)
 
 
-_OPENAI_PREFIXES = (
-    "chatgpt",
-    "gpt",
-    "text-embedding",
-    "o1",
-    "o3",
-    "o4",
-    "codex",
-    "computer-use",
-)
-_CODEX_PROVIDER_MODELS = frozenset(
-    {
-        "gpt-5.5",
-        "gpt-5.4",
-        "gpt-5.4-mini",
-        "gpt-5.3-codex",
-        "gpt-5.3-codex-spark",
-        "gpt-5.2-codex",
-        "gpt-5.1-codex-max",
-        "gpt-5.2",
-        "gpt-5.1-codex-mini",
-    }
-)
-_CODEX_SUBSCRIPTION_MODELS = frozenset(
-    {
-        "chatgpt-4o-latest",
-        "codex-mini-latest",
-        "computer-use-preview",
-        "gpt-5",
-        "gpt-5.5",
-        "gpt-5.4",
-        "gpt-5.4-mini",
-        "gpt-5-chat-latest",
-        "gpt-5-codex",
-        "gpt-5-mini",
-        "gpt-5-nano",
-        "gpt-5.1",
-        "gpt-5.1-chat-latest",
-        "gpt-5.1-codex",
-        "gpt-5.1-codex-max",
-        "gpt-5.1-codex-mini",
-        "gpt-5.2",
-        "gpt-5.2-codex",
-        "gpt-5.3-codex",
-        "gpt-5.3-codex-spark",
-    }
-)
 _TOGETHER_PREFIXES = (
     "meta-llama/",
     "Qwen/",
@@ -172,20 +134,6 @@ def _openai_compatible(
     )
 
 
-def _is_openai_family_model(model_name: str) -> bool:
-    return model_name.startswith(_OPENAI_PREFIXES) and not model_name.startswith("openai/gpt-oss")
-
-
-def _is_codex_subscription_model(model_name: str) -> bool:
-    """Return True when model_name is known to be available through Codex auth."""
-    return model_name in _CODEX_SUBSCRIPTION_MODELS
-
-
-def is_codex_provider_model(model_name: str) -> bool:
-    """Return True when model_name belongs to the explicit Codex UI provider catalog."""
-    return model_name in _CODEX_PROVIDER_MODELS
-
-
 def _codex_cli(
     model_name: str,
     model_config: dict[str, Any] | None,
@@ -220,81 +168,6 @@ def _codex_native(
         token_callback=token_callback,
         thinking_callback=thinking_callback,
     )
-
-
-@lru_cache(maxsize=1)
-def _is_codex_cli_auth_available() -> bool:
-    """Return True when Codex CLI is installed and has an authenticated login."""
-    if os.environ.get("KISS_DISABLE_CODEX_AUTH") == "1":
-        return False
-    codex_path = shutil.which("codex")
-    if not codex_path:
-        return False
-    try:
-        result = subprocess.run(
-            [codex_path, "login", "status"],
-            check=False,
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return False
-    if result.returncode != 0:
-        return False
-    status_text = f"{result.stdout}\n{result.stderr}".lower()
-    return "logged in" in status_text
-
-
-@lru_cache(maxsize=1)
-def _is_codex_native_auth_available() -> bool:
-    """Return True when native Codex OAuth credentials are locally available."""
-    if os.environ.get("KISS_DISABLE_CODEX_AUTH") == "1":
-        return False
-    try:
-        from kiss.core.models.codex_oauth import OpenAICodexOAuthManager
-
-        return OpenAICodexOAuthManager().has_credentials()
-    except Exception:
-        return False
-
-
-def _is_codex_auth_available() -> bool:
-    """Return True when either native OAuth or Codex CLI auth is available."""
-    return _is_codex_native_auth_available() or _is_codex_cli_auth_available()
-
-
-def _resolve_codex_transport() -> str:
-    """Resolve Codex transport backend: native first, CLI fallback."""
-    forced = os.environ.get("KISS_CODEX_TRANSPORT", "").strip().lower()
-    if forced in {"native", "oauth", "direct"}:
-        return "native" if _is_codex_native_auth_available() else "cli"
-    if forced in {"cli", "exec", "subprocess"}:
-        return "cli"
-    if _is_codex_native_auth_available():
-        return "native"
-    return "cli"
-
-
-def _resolve_openai_auth_mode(model_name: str, openai_api_key: str) -> str:
-    """Resolve platform API key auth vs ChatGPT/Codex subscription auth."""
-    forced = os.environ.get("KISS_OPENAI_AUTH", "").strip().lower()
-    if forced in {"api", "api_key", "platform"}:
-        return "api"
-    if forced in {"codex", "subscription", "chatgpt"}:
-        if _is_codex_auth_available() and _is_codex_subscription_model(model_name):
-            return "codex"
-        return "api"
-
-    codex_auth = _is_codex_auth_available()
-    supports_codex = _is_codex_subscription_model(model_name)
-    if codex_auth and supports_codex:
-        return "codex"
-    if openai_api_key:
-        return "api"
-    if codex_auth and supports_codex:
-        return "codex"
-    return "api"
 
 
 MODEL_INFO: dict[str, ModelInfo] = {
@@ -908,7 +781,7 @@ def _strip_provider_prefix(model_name: str) -> str:
     """Strip harbor-style provider prefixes that duplicate KISS's own routing.
 
     Harbor (and other frameworks) pass model names as ``provider/model``
-    (e.g. ``openai/gpt-5.5``, ``anthropic/claude-opus-4-6``,
+    (e.g. ``openai/gpt-5.4``, ``anthropic/claude-opus-4-6``,
     ``google/gemini-2.5-pro``).  KISS already routes by the model name
     itself (``gpt-*`` → OpenAI, ``claude-*`` → Anthropic, etc.), so the
     provider prefix is redundant and must be stripped.
@@ -947,7 +820,7 @@ def model(
     Args:
         model_name: The name of the model (with provider prefix if applicable).
             Accepts harbor-style ``provider/model`` names (e.g.
-            ``openai/gpt-5.5``, ``anthropic/claude-opus-4-6``) — the
+            ``openai/gpt-5.4``, ``anthropic/claude-opus-4-6``) — the
             redundant provider prefix is stripped automatically.
         model_config: Optional dictionary of model configuration parameters.
             If it contains "base_url", routing is bypassed and an OpenAICompatibleModel
@@ -1141,9 +1014,9 @@ def get_default_model() -> str:
     if keys.GEMINI_API_KEY:
         return "gemini-3.1-pro-preview"
     if keys.OPENAI_API_KEY:
-        return "gpt-5.5"
+        return "gpt-5.4"
     if _is_codex_auth_available():
-        return "gpt-5.5"
+        return "gpt-5.4"
     if keys.TOGETHER_API_KEY:
         return "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8"
     return "claude-opus-4-6"

--- a/src/kiss/core/models/openai_auth_routing.py
+++ b/src/kiss/core/models/openai_auth_routing.py
@@ -1,0 +1,132 @@
+# Author: Koushik Sen (ksen@berkeley.edu)
+# Contributors:
+# Koushik Sen (ksen@berkeley.edu)
+# add your name here
+
+"""OpenAI/Codex auth routing helpers."""
+
+import os
+import shutil
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+
+CODEX_AUTH_DISABLED_FILE = Path("~/.kiss/codex_auth_disabled").expanduser()
+
+_OPENAI_PREFIXES = (
+    "chatgpt",
+    "gpt",
+    "text-embedding",
+    "o1",
+    "o3",
+    "o4",
+    "codex",
+    "computer-use",
+)
+_CODEX_SUBSCRIPTION_MODEL_ORDER = (
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex",
+    "gpt-5.3-codex-spark",
+    "gpt-5.2",
+)
+_CODEX_PROVIDER_MODELS = frozenset(_CODEX_SUBSCRIPTION_MODEL_ORDER)
+_CODEX_SUBSCRIPTION_MODELS = frozenset(_CODEX_SUBSCRIPTION_MODEL_ORDER)
+
+
+def _is_openai_family_model(model_name: str) -> bool:
+    return model_name.startswith(_OPENAI_PREFIXES) and not model_name.startswith("openai/gpt-oss")
+
+
+def _is_codex_subscription_model(model_name: str) -> bool:
+    """Return True when model_name is known to be available through Codex auth."""
+    return model_name in _CODEX_SUBSCRIPTION_MODELS
+
+
+def is_codex_provider_model(model_name: str) -> bool:
+    """Return True when model_name belongs to the explicit Codex UI provider catalog."""
+    return model_name in _CODEX_PROVIDER_MODELS
+
+
+def codex_subscription_model_sort_order(model_name: str) -> int:
+    """Return the official Codex Pro picker order for a subscription model."""
+    try:
+        return _CODEX_SUBSCRIPTION_MODEL_ORDER.index(model_name)
+    except ValueError:
+        return len(_CODEX_SUBSCRIPTION_MODEL_ORDER)
+
+
+@lru_cache(maxsize=1)
+def _is_codex_cli_auth_available() -> bool:
+    """Return True when Codex CLI is installed and has an authenticated login."""
+    if os.environ.get("KISS_DISABLE_CODEX_AUTH") == "1" or CODEX_AUTH_DISABLED_FILE.exists():
+        return False
+    codex_path = shutil.which("codex")
+    if not codex_path:
+        return False
+    try:
+        result = subprocess.run(
+            [codex_path, "login", "status"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if result.returncode != 0:
+        return False
+    status_text = f"{result.stdout}\n{result.stderr}".lower()
+    return "logged in" in status_text
+
+
+@lru_cache(maxsize=1)
+def _is_codex_native_auth_available() -> bool:
+    """Return True when native Codex OAuth credentials are locally available."""
+    if os.environ.get("KISS_DISABLE_CODEX_AUTH") == "1" or CODEX_AUTH_DISABLED_FILE.exists():
+        return False
+    try:
+        from kiss.core.models.codex_oauth import OpenAICodexOAuthManager
+
+        return OpenAICodexOAuthManager().has_credentials()
+    except Exception:
+        return False
+
+
+def _is_codex_auth_available() -> bool:
+    """Return True when either native OAuth or Codex CLI auth is available."""
+    return _is_codex_native_auth_available() or _is_codex_cli_auth_available()
+
+
+def _resolve_codex_transport() -> str:
+    """Resolve Codex transport backend: native first, CLI fallback."""
+    forced = os.environ.get("KISS_CODEX_TRANSPORT", "").strip().lower()
+    if forced in {"native", "oauth", "direct"}:
+        return "native" if _is_codex_native_auth_available() else "cli"
+    if forced in {"cli", "exec", "subprocess"}:
+        return "cli"
+    if _is_codex_native_auth_available():
+        return "native"
+    return "cli"
+
+
+def _resolve_openai_auth_mode(model_name: str, openai_api_key: str) -> str:
+    """Resolve platform API key auth vs ChatGPT/Codex subscription auth."""
+    forced = os.environ.get("KISS_OPENAI_AUTH", "").strip().lower()
+    if forced in {"api", "api_key", "platform"}:
+        return "api"
+    if forced in {"codex", "subscription", "chatgpt"}:
+        if _is_codex_auth_available() and _is_codex_subscription_model(model_name):
+            return "codex"
+        return "api"
+
+    codex_auth = _is_codex_auth_available()
+    supports_codex = _is_codex_subscription_model(model_name)
+    if codex_auth and supports_codex:
+        return "codex"
+    if openai_api_key:
+        return "api"
+    if codex_auth and supports_codex:
+        return "codex"
+    return "api"

--- a/src/kiss/tests/core/test_uncovered_branches.py
+++ b/src/kiss/tests/core/test_uncovered_branches.py
@@ -208,12 +208,15 @@ class TestGetAvailableModels:
         result = get_most_expensive_model()
         assert isinstance(result, str)
 
-    def test_get_default_model_priority(self) -> None:
+    def test_get_default_model_priority(self, monkeypatch) -> None:
         """Test that get_default_model picks the right model per API key priority."""
         import os
 
         from kiss.core import config as config_module
+        from kiss.core.models import model_info
         from kiss.core.models.model_info import get_default_model
+
+        monkeypatch.setattr(model_info, "_is_codex_auth_available", lambda: False)
 
         env_keys = [
             "ANTHROPIC_API_KEY",
@@ -235,7 +238,7 @@ class TestGetAvailableModels:
 
             os.environ["OPENAI_API_KEY"] = "t"
             config_module.DEFAULT_CONFIG = config_module.Config()
-            assert get_default_model() == "gpt-5.4"
+            assert get_default_model() == "gpt-5.5"
 
             os.environ["GEMINI_API_KEY"] = "t"
             config_module.DEFAULT_CONFIG = config_module.Config()

--- a/src/kiss/tests/test_codex_model_routing.py
+++ b/src/kiss/tests/test_codex_model_routing.py
@@ -1,0 +1,121 @@
+"""Tests for Codex auth routing for OpenAI-family models."""
+
+from kiss.core import config as config_module
+from kiss.core.models import model_info
+
+
+def test_codex_subscription_model_allowlist():
+    assert model_info._is_codex_subscription_model("gpt-5.5")
+    assert model_info._is_codex_subscription_model("gpt-5.3-codex")
+    assert model_info._is_codex_subscription_model("gpt-5.3-codex-spark")
+    assert model_info._is_codex_subscription_model("gpt-5.2")
+    assert not model_info._is_codex_subscription_model("gpt-4.1-mini")
+
+
+def test_codex_provider_catalog_allowlist():
+    expected = {
+        "gpt-5.5",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+        "gpt-5.2-codex",
+        "gpt-5.1-codex-max",
+        "gpt-5.2",
+        "gpt-5.1-codex-mini",
+    }
+    for model in expected:
+        assert model_info.is_codex_provider_model(model)
+    assert not model_info.is_codex_provider_model("gpt-5-mini")
+
+
+def test_resolve_openai_auth_mode_prefers_codex_models_when_available(monkeypatch):
+    monkeypatch.delenv("KISS_OPENAI_AUTH", raising=False)
+    monkeypatch.setattr(model_info, "_is_codex_auth_available", lambda: True)
+    mode = model_info._resolve_openai_auth_mode("gpt-5.3-codex", "sk-test")
+    assert mode == "codex"
+
+
+def test_resolve_openai_auth_mode_uses_api_for_non_codex_when_key_present(monkeypatch):
+    monkeypatch.delenv("KISS_OPENAI_AUTH", raising=False)
+    monkeypatch.setattr(model_info, "_is_codex_auth_available", lambda: True)
+    mode = model_info._resolve_openai_auth_mode("gpt-4.1-mini", "sk-test")
+    assert mode == "api"
+
+
+def test_resolve_openai_auth_mode_uses_codex_without_key(monkeypatch):
+    monkeypatch.delenv("KISS_OPENAI_AUTH", raising=False)
+    monkeypatch.setattr(model_info, "_is_codex_auth_available", lambda: True)
+    mode = model_info._resolve_openai_auth_mode("gpt-5-mini", "")
+    assert mode == "codex"
+
+
+def test_resolve_openai_auth_mode_uses_api_without_key_for_api_only_model(monkeypatch):
+    monkeypatch.delenv("KISS_OPENAI_AUTH", raising=False)
+    monkeypatch.setattr(model_info, "_is_codex_auth_available", lambda: True)
+    mode = model_info._resolve_openai_auth_mode("gpt-4.1-mini", "")
+    assert mode == "api"
+
+
+def test_resolve_openai_auth_mode_respects_forced_env(monkeypatch):
+    monkeypatch.setenv("KISS_OPENAI_AUTH", "api")
+    monkeypatch.setattr(model_info, "_is_codex_auth_available", lambda: True)
+    mode = model_info._resolve_openai_auth_mode("gpt-5.3-codex", "")
+    assert mode == "api"
+
+
+def test_resolve_codex_transport_prefers_native(monkeypatch):
+    monkeypatch.delenv("KISS_CODEX_TRANSPORT", raising=False)
+    monkeypatch.setattr(model_info, "_is_codex_native_auth_available", lambda: True)
+    assert model_info._resolve_codex_transport() == "native"
+
+
+def test_resolve_codex_transport_forced_native_falls_back_to_cli(monkeypatch):
+    monkeypatch.setenv("KISS_CODEX_TRANSPORT", "native")
+    monkeypatch.setattr(model_info, "_is_codex_native_auth_available", lambda: False)
+    assert model_info._resolve_codex_transport() == "cli"
+
+
+def test_resolve_codex_transport_forced_cli(monkeypatch):
+    monkeypatch.setenv("KISS_CODEX_TRANSPORT", "cli")
+    monkeypatch.setattr(model_info, "_is_codex_native_auth_available", lambda: True)
+    assert model_info._resolve_codex_transport() == "cli"
+
+
+def test_model_openai_routing_prefers_native_codex_backend(monkeypatch):
+    monkeypatch.setattr(model_info, "_resolve_openai_auth_mode", lambda *_args: "codex")
+    monkeypatch.setattr(model_info, "_resolve_codex_transport", lambda: "native")
+    monkeypatch.setattr(model_info, "_is_codex_native_auth_available", lambda: True)
+
+    sentinel = object()
+    monkeypatch.setattr(model_info, "_codex_native", lambda *_args, **_kwargs: sentinel)
+
+    m = model_info.model("gpt-4.1-mini")
+    assert m is sentinel
+
+
+def test_model_openai_routing_falls_back_to_cli_when_native_missing(monkeypatch):
+    monkeypatch.setattr(model_info, "_resolve_openai_auth_mode", lambda *_args: "codex")
+    monkeypatch.setattr(model_info, "_resolve_codex_transport", lambda: "native")
+    monkeypatch.setattr(model_info, "_is_codex_native_auth_available", lambda: False)
+    monkeypatch.setattr(model_info, "_is_codex_cli_auth_available", lambda: True)
+
+    sentinel = object()
+    monkeypatch.setattr(model_info, "_codex_cli", lambda *_args, **_kwargs: sentinel)
+
+    m = model_info.model("gpt-4.1-mini")
+    assert m is sentinel
+
+
+def test_get_available_models_includes_openai_with_codex_auth(monkeypatch):
+    monkeypatch.setattr(model_info, "_is_codex_auth_available", lambda: True)
+    monkeypatch.setattr(config_module.DEFAULT_CONFIG, "OPENAI_API_KEY", "")
+    names = model_info.get_available_models()
+    assert "gpt-4.1-mini" not in names
+    assert "gpt-5.5" in names
+    assert "gpt-5.3-codex" in names
+
+
+def test_get_available_models_excludes_openai_without_key_or_codex(monkeypatch):
+    monkeypatch.setattr(model_info, "_is_codex_auth_available", lambda: False)
+    monkeypatch.setattr(config_module.DEFAULT_CONFIG, "OPENAI_API_KEY", "")
+    names = model_info.get_available_models()
+    assert "gpt-4.1-mini" not in names

--- a/src/kiss/tests/test_codex_model_routing.py
+++ b/src/kiss/tests/test_codex_model_routing.py
@@ -1,83 +1,136 @@
 """Tests for Codex auth routing for OpenAI-family models."""
 
 from kiss.core import config as config_module
-from kiss.core.models import model_info
+from kiss.core.models import model_info, openai_auth_routing
+
+
+def test_vscode_model_dropdown_labels_codex_subscription_models(monkeypatch):
+    from kiss.agents.vscode import server as vscode_server
+
+    monkeypatch.setattr(config_module.DEFAULT_CONFIG, "OPENAI_API_KEY", "")
+    monkeypatch.setattr(openai_auth_routing, "_is_codex_auth_available", lambda: True)
+
+    vendor, order = vscode_server._model_dropdown_vendor("gpt-5.4")
+
+    assert vendor == "OpenAI Codex subscription"
+    assert order == 1.0
+
+
+def test_vscode_model_dropdown_labels_openai_api_models(monkeypatch):
+    from kiss.agents.vscode import server as vscode_server
+
+    monkeypatch.setattr(config_module.DEFAULT_CONFIG, "OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr(openai_auth_routing, "_is_codex_auth_available", lambda: False)
+
+    vendor, order = vscode_server._model_dropdown_vendor("gpt-5.4")
+
+    assert vendor == "OpenAI API"
+    assert order == 1.1
 
 
 def test_codex_subscription_model_allowlist():
-    assert model_info._is_codex_subscription_model("gpt-5.5")
-    assert model_info._is_codex_subscription_model("gpt-5.3-codex")
-    assert model_info._is_codex_subscription_model("gpt-5.3-codex-spark")
-    assert model_info._is_codex_subscription_model("gpt-5.2")
-    assert not model_info._is_codex_subscription_model("gpt-4.1-mini")
+    assert openai_auth_routing._is_codex_subscription_model("gpt-5.5")
+    assert openai_auth_routing._is_codex_subscription_model("gpt-5.4")
+    assert openai_auth_routing._is_codex_subscription_model("gpt-5.4-mini")
+    assert openai_auth_routing._is_codex_subscription_model("gpt-5.3-codex")
+    assert openai_auth_routing._is_codex_subscription_model("gpt-5.3-codex-spark")
+    assert openai_auth_routing._is_codex_subscription_model("gpt-5.2")
+    assert not openai_auth_routing._is_codex_subscription_model("gpt-5-mini")
+    assert not openai_auth_routing._is_codex_subscription_model("gpt-5-codex")
+    assert not openai_auth_routing._is_codex_subscription_model("gpt-5.2-codex")
+    assert not openai_auth_routing._is_codex_subscription_model("codex-mini-latest")
+    assert not openai_auth_routing._is_codex_subscription_model("computer-use-preview")
+    assert not openai_auth_routing._is_codex_subscription_model("gpt-4.1-mini")
+
+
+def test_codex_subscription_model_sort_order_matches_pro_picker():
+    expected = [
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+        "gpt-5.2",
+    ]
+
+    actual = sorted(expected, key=openai_auth_routing.codex_subscription_model_sort_order)
+
+    assert actual == expected
 
 
 def test_codex_provider_catalog_allowlist():
     expected = {
         "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini",
         "gpt-5.3-codex",
         "gpt-5.3-codex-spark",
-        "gpt-5.2-codex",
-        "gpt-5.1-codex-max",
         "gpt-5.2",
-        "gpt-5.1-codex-mini",
     }
     for model in expected:
-        assert model_info.is_codex_provider_model(model)
-    assert not model_info.is_codex_provider_model("gpt-5-mini")
+        assert openai_auth_routing.is_codex_provider_model(model)
+    assert not openai_auth_routing.is_codex_provider_model("gpt-5-mini")
+    assert not openai_auth_routing.is_codex_provider_model("gpt-5.2-codex")
 
 
 def test_resolve_openai_auth_mode_prefers_codex_models_when_available(monkeypatch):
     monkeypatch.delenv("KISS_OPENAI_AUTH", raising=False)
-    monkeypatch.setattr(model_info, "_is_codex_auth_available", lambda: True)
-    mode = model_info._resolve_openai_auth_mode("gpt-5.3-codex", "sk-test")
+    monkeypatch.setattr(openai_auth_routing, "_is_codex_auth_available", lambda: True)
+    mode = openai_auth_routing._resolve_openai_auth_mode("gpt-5.3-codex", "sk-test")
     assert mode == "codex"
 
 
 def test_resolve_openai_auth_mode_uses_api_for_non_codex_when_key_present(monkeypatch):
     monkeypatch.delenv("KISS_OPENAI_AUTH", raising=False)
-    monkeypatch.setattr(model_info, "_is_codex_auth_available", lambda: True)
-    mode = model_info._resolve_openai_auth_mode("gpt-4.1-mini", "sk-test")
+    monkeypatch.setattr(openai_auth_routing, "_is_codex_auth_available", lambda: True)
+    mode = openai_auth_routing._resolve_openai_auth_mode("gpt-4.1-mini", "sk-test")
     assert mode == "api"
 
 
 def test_resolve_openai_auth_mode_uses_codex_without_key(monkeypatch):
     monkeypatch.delenv("KISS_OPENAI_AUTH", raising=False)
-    monkeypatch.setattr(model_info, "_is_codex_auth_available", lambda: True)
-    mode = model_info._resolve_openai_auth_mode("gpt-5-mini", "")
+    monkeypatch.setattr(openai_auth_routing, "_is_codex_auth_available", lambda: True)
+    mode = openai_auth_routing._resolve_openai_auth_mode("gpt-5.2", "")
     assert mode == "codex"
+
+
+def test_resolve_openai_auth_mode_uses_api_for_non_pro_codex_model(monkeypatch):
+    monkeypatch.delenv("KISS_OPENAI_AUTH", raising=False)
+    monkeypatch.setattr(openai_auth_routing, "_is_codex_auth_available", lambda: True)
+    mode = openai_auth_routing._resolve_openai_auth_mode("gpt-5-mini", "sk-test")
+    assert mode == "api"
 
 
 def test_resolve_openai_auth_mode_uses_api_without_key_for_api_only_model(monkeypatch):
     monkeypatch.delenv("KISS_OPENAI_AUTH", raising=False)
-    monkeypatch.setattr(model_info, "_is_codex_auth_available", lambda: True)
-    mode = model_info._resolve_openai_auth_mode("gpt-4.1-mini", "")
+    monkeypatch.setattr(openai_auth_routing, "_is_codex_auth_available", lambda: True)
+    mode = openai_auth_routing._resolve_openai_auth_mode("gpt-4.1-mini", "")
     assert mode == "api"
 
 
 def test_resolve_openai_auth_mode_respects_forced_env(monkeypatch):
     monkeypatch.setenv("KISS_OPENAI_AUTH", "api")
-    monkeypatch.setattr(model_info, "_is_codex_auth_available", lambda: True)
-    mode = model_info._resolve_openai_auth_mode("gpt-5.3-codex", "")
+    monkeypatch.setattr(openai_auth_routing, "_is_codex_auth_available", lambda: True)
+    mode = openai_auth_routing._resolve_openai_auth_mode("gpt-5.3-codex", "")
     assert mode == "api"
 
 
 def test_resolve_codex_transport_prefers_native(monkeypatch):
     monkeypatch.delenv("KISS_CODEX_TRANSPORT", raising=False)
-    monkeypatch.setattr(model_info, "_is_codex_native_auth_available", lambda: True)
-    assert model_info._resolve_codex_transport() == "native"
+    monkeypatch.setattr(openai_auth_routing, "_is_codex_native_auth_available", lambda: True)
+    assert openai_auth_routing._resolve_codex_transport() == "native"
 
 
 def test_resolve_codex_transport_forced_native_falls_back_to_cli(monkeypatch):
     monkeypatch.setenv("KISS_CODEX_TRANSPORT", "native")
-    monkeypatch.setattr(model_info, "_is_codex_native_auth_available", lambda: False)
-    assert model_info._resolve_codex_transport() == "cli"
+    monkeypatch.setattr(openai_auth_routing, "_is_codex_native_auth_available", lambda: False)
+    assert openai_auth_routing._resolve_codex_transport() == "cli"
 
 
 def test_resolve_codex_transport_forced_cli(monkeypatch):
     monkeypatch.setenv("KISS_CODEX_TRANSPORT", "cli")
-    monkeypatch.setattr(model_info, "_is_codex_native_auth_available", lambda: True)
-    assert model_info._resolve_codex_transport() == "cli"
+    monkeypatch.setattr(openai_auth_routing, "_is_codex_native_auth_available", lambda: True)
+    assert openai_auth_routing._resolve_codex_transport() == "cli"
 
 
 def test_model_openai_routing_prefers_native_codex_backend(monkeypatch):
@@ -110,8 +163,13 @@ def test_get_available_models_includes_openai_with_codex_auth(monkeypatch):
     monkeypatch.setattr(config_module.DEFAULT_CONFIG, "OPENAI_API_KEY", "")
     names = model_info.get_available_models()
     assert "gpt-4.1-mini" not in names
-    assert "gpt-5.5" in names
+    assert "gpt-5.4" in names
+    assert "gpt-5.4-mini" in names
     assert "gpt-5.3-codex" in names
+    assert "gpt-5.3-codex-spark" in names
+    assert "gpt-5.2" in names
+    assert "gpt-5-mini" not in names
+    assert "gpt-5-codex" not in names
 
 
 def test_get_available_models_excludes_openai_without_key_or_codex(monkeypatch):

--- a/src/kiss/tests/test_codex_oauth_manager.py
+++ b/src/kiss/tests/test_codex_oauth_manager.py
@@ -1,0 +1,173 @@
+"""Unit tests for native Codex OAuth credential management."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+import urllib.parse
+from pathlib import Path
+
+from kiss.core.models import codex_oauth
+
+
+def _jwt(claims: dict[str, object]) -> str:
+    def enc(value: dict[str, object]) -> str:
+        raw = json.dumps(value, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    return f"{enc({'alg': 'none', 'typ': 'JWT'})}.{enc(claims)}."
+
+
+def test_manager_loads_credentials_from_codex_auth_file(tmp_path: Path):
+    auth_file = tmp_path / "auth.json"
+    access = _jwt({"exp": int(time.time()) + 3600})
+    auth_file.write_text(
+        json.dumps(
+            {
+                "last_refresh": "2026-03-04T12:00:00+00:00",
+                "tokens": {
+                    "access_token": access,
+                    "refresh_token": "rtok",
+                    "id_token": _jwt(
+                        {
+                            "exp": int(time.time()) + 3600,
+                            "https://api.openai.com/auth": {"chatgpt_account_id": "acct-123"},
+                        }
+                    ),
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cache_file = tmp_path / "cache.json"
+    manager = codex_oauth.OpenAICodexOAuthManager(
+        cache_file=str(cache_file),
+        source_file=str(auth_file),
+    )
+
+    assert manager.has_credentials()
+    assert manager.get_account_id() == "acct-123"
+    assert manager.get_access_token() == access
+
+
+def test_manager_refreshes_expired_token(tmp_path: Path, monkeypatch):
+    cache_file = tmp_path / "cache.json"
+    expired = _jwt({"exp": int(time.time()) - 10})
+    cache_file.write_text(
+        json.dumps(
+            {
+                "type": "openai-codex",
+                "access_token": expired,
+                "refresh_token": "refresh-old",
+                "id_token": _jwt({"exp": int(time.time()) - 10}),
+                "account_id": "acct-old",
+                "expires_at": time.time() - 10,
+                "updated_at": time.time() - 30,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    refreshed_access = _jwt({"exp": int(time.time()) + 7200})
+    refreshed_id = _jwt({"chatgpt_account_id": "acct-new", "exp": int(time.time()) + 7200})
+
+    class _DummyResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "access_token": refreshed_access,
+                    "refresh_token": "refresh-new",
+                    "id_token": refreshed_id,
+                    "expires_in": 7200,
+                }
+            ).encode("utf-8")
+
+    def _fake_urlopen(_request, timeout: float):  # noqa: ANN001
+        assert timeout > 0
+        return _DummyResponse()
+
+    monkeypatch.setattr(codex_oauth.urllib.request, "urlopen", _fake_urlopen)
+
+    manager = codex_oauth.OpenAICodexOAuthManager(
+        cache_file=str(cache_file),
+        source_file=str(tmp_path / "missing-auth.json"),
+    )
+    token = manager.get_access_token()
+
+    assert token == refreshed_access
+    assert manager.get_account_id() == "acct-new"
+
+    persisted = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert persisted["refresh_token"] == "refresh-new"
+
+
+def test_pkce_helpers_generate_valid_values():
+    verifier = codex_oauth.generate_code_verifier()
+    challenge = codex_oauth.generate_code_challenge(verifier)
+    state = codex_oauth.generate_oauth_state()
+
+    assert len(verifier) >= 43
+    assert challenge
+    assert len(state) == 32
+
+
+def test_build_authorization_url_contains_required_params():
+    url = codex_oauth.build_authorization_url("challenge-123", "state-abc")
+    parsed = urllib.parse.urlparse(url)
+    params = urllib.parse.parse_qs(parsed.query)
+
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "auth.openai.com"
+    assert params["client_id"][0] == codex_oauth.CODEX_OAUTH_CLIENT_ID
+    assert params["response_type"][0] == "code"
+    assert params["code_challenge_method"][0] == "S256"
+    assert params["codex_cli_simplified_flow"][0] == "true"
+    assert params["originator"][0] == "kiss-ai"
+
+
+def test_manager_exchanges_authorization_code_and_persists(tmp_path: Path, monkeypatch):
+    cache_file = tmp_path / "cache.json"
+    refreshed_access = _jwt({"exp": int(time.time()) + 7200})
+    refreshed_id = _jwt({"chatgpt_account_id": "acct-login", "exp": int(time.time()) + 7200})
+
+    class _DummyResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "access_token": refreshed_access,
+                    "refresh_token": "refresh-login",
+                    "id_token": refreshed_id,
+                    "expires_in": 7200,
+                }
+            ).encode("utf-8")
+
+    def _fake_urlopen(_request, timeout: float):  # noqa: ANN001
+        assert timeout > 0
+        return _DummyResponse()
+
+    monkeypatch.setattr(codex_oauth.urllib.request, "urlopen", _fake_urlopen)
+
+    manager = codex_oauth.OpenAICodexOAuthManager(
+        cache_file=str(cache_file),
+        source_file=str(tmp_path / "missing-auth.json"),
+    )
+    token = manager.exchange_authorization_code("code-123", "verifier-123")
+
+    assert token == refreshed_access
+    assert manager.get_account_id() == "acct-login"
+    persisted = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert persisted["refresh_token"] == "refresh-login"

--- a/src/kiss/tests/test_codex_vscode_auth.py
+++ b/src/kiss/tests/test_codex_vscode_auth.py
@@ -1,0 +1,71 @@
+"""Tests for VS Code OpenAI Codex auth command wiring."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from kiss.agents.vscode.commands import _CommandsMixin
+
+
+class _Printer:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    def broadcast(self, event: dict[str, Any]) -> None:
+        self.events.append(event)
+
+
+class _Server(_CommandsMixin):
+    def __init__(self) -> None:
+        self.printer = cast(Any, _Printer())
+
+
+def test_codex_auth_refresh_broadcasts_status(monkeypatch):
+    def _status(model_name: str = "") -> dict[str, Any]:
+        return {
+            "model": model_name,
+            "codex_auth_available": True,
+            "preferred_auth": "codex",
+        }
+
+    monkeypatch.setattr("kiss.agents.vscode.vscode_config.get_codex_auth_status", _status)
+
+    server = _Server()
+    server._cmd_codex_auth({"type": "codexAuth", "action": "refresh", "model": "gpt-5.5"})
+
+    printer = cast(_Printer, server.printer)
+    assert printer.events == [
+        {
+            "type": "codexAuth",
+            "status": "ok",
+            "auth": {
+                "model": "gpt-5.5",
+                "codex_auth_available": True,
+                "preferred_auth": "codex",
+            },
+        }
+    ]
+
+
+def test_codex_auth_login_broadcasts_login_url(monkeypatch):
+    def _login(model_name: str = "") -> dict[str, Any]:
+        return {
+            "status": "ok",
+            "login_url": "https://auth.openai.com/oauth/authorize",
+            "auth": {"model": model_name, "login_pending": True},
+        }
+
+    monkeypatch.setattr("kiss.agents.vscode.vscode_config.start_codex_login", _login)
+
+    server = _Server()
+    server._cmd_codex_auth({"type": "codexAuth", "action": "login", "model": "gpt-5.5"})
+
+    printer = cast(_Printer, server.printer)
+    assert printer.events == [
+        {
+            "type": "codexAuth",
+            "status": "ok",
+            "login_url": "https://auth.openai.com/oauth/authorize",
+            "auth": {"model": "gpt-5.5", "login_pending": True},
+        }
+    ]

--- a/src/kiss/tests/test_codex_vscode_auth.py
+++ b/src/kiss/tests/test_codex_vscode_auth.py
@@ -31,7 +31,7 @@ def test_codex_auth_refresh_broadcasts_status(monkeypatch):
     monkeypatch.setattr("kiss.agents.vscode.vscode_config.get_codex_auth_status", _status)
 
     server = _Server()
-    server._cmd_codex_auth({"type": "codexAuth", "action": "refresh", "model": "gpt-5.5"})
+    server._cmd_codex_auth({"type": "codexAuth", "action": "refresh", "model": "gpt-5.4"})
 
     printer = cast(_Printer, server.printer)
     assert printer.events == [
@@ -39,7 +39,7 @@ def test_codex_auth_refresh_broadcasts_status(monkeypatch):
             "type": "codexAuth",
             "status": "ok",
             "auth": {
-                "model": "gpt-5.5",
+                "model": "gpt-5.4",
                 "codex_auth_available": True,
                 "preferred_auth": "codex",
             },
@@ -58,7 +58,7 @@ def test_codex_auth_login_broadcasts_login_url(monkeypatch):
     monkeypatch.setattr("kiss.agents.vscode.vscode_config.start_codex_login", _login)
 
     server = _Server()
-    server._cmd_codex_auth({"type": "codexAuth", "action": "login", "model": "gpt-5.5"})
+    server._cmd_codex_auth({"type": "codexAuth", "action": "login", "model": "gpt-5.4"})
 
     printer = cast(_Printer, server.printer)
     assert printer.events == [
@@ -66,6 +66,6 @@ def test_codex_auth_login_broadcasts_login_url(monkeypatch):
             "type": "codexAuth",
             "status": "ok",
             "login_url": "https://auth.openai.com/oauth/authorize",
-            "auth": {"model": "gpt-5.5", "login_pending": True},
+            "auth": {"model": "gpt-5.4", "login_pending": True},
         }
     ]


### PR DESCRIPTION
Hello,

another attempt to build upon the great progress since last time, happy to see the extended support for more providers.

With this PR I'd like to propose the ability to connect OpenAI's subscription with auth support, incl. setup page, model selection list update and tests.

It introduces native Codex OAuth handling, a Codex-backed OpenAI model path, and VS Code/web UI controls for logging in, logging out, and refreshing Codex auth status. The model picker now separates Codex subscription models from OpenAI API-key models, uses the Codex Pro model list, and hides per-token pricing for subscription-backed models.

It also keeps API-key OpenAI models available as a separate group when an OpenAI API key is configured, so the two auth paths do not get mixed together.

Test coverage was added for Codex OAuth handling, auth routing, model availability, and VS Code auth status behavior.