### PR TITLE
Add custom HTTP header support for Sorcar CLI

### DIFF
--- a/src/kiss/agents/sorcar/cli_helpers.py
+++ b/src/kiss/agents/sorcar/cli_helpers.py
@@ -55,6 +55,10 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "-e", "--endpoint", type=str, default=None, help="Custom endpoint for local model"
     )
     parser.add_argument(
+        "--header", action="append", type=str, default=None,
+        help="Custom HTTP header (format: 'Key:Value'). Can be used multiple times.",
+    )
+    parser.add_argument(
         "-b", "--max_budget", type=float, default=DEFAULT_CONFIG.max_budget,
         help="Maximum budget in USD",
     )
@@ -129,6 +133,14 @@ def _build_run_kwargs(args: argparse.Namespace) -> dict[str, Any]:
     model_config: dict[str, Any] = {}
     if args.endpoint:
         model_config["base_url"] = args.endpoint
+    if args.header:
+        headers = {}
+        for h in args.header:
+            if ":" in h:
+                key, value = h.split(":", 1)
+                headers[key.strip()] = value.strip()
+        if headers:
+            model_config["extra_headers"] = headers
 
     return {
         "prompt_template": task_description,

--- a/src/kiss/core/models/openai_compatible_model.py
+++ b/src/kiss/core/models/openai_compatible_model.py
@@ -152,10 +152,12 @@ class OpenAICompatibleModel(Model):
             prompt: The initial user prompt to start the conversation.
             attachments: Optional list of file attachments (images, PDFs) to include.
         """
+        extra_headers = self.model_config.get("extra_headers") or {}
         self.client = OpenAI(
             base_url=self.base_url,
             api_key=self.api_key,
             timeout=1800.0,
+            default_headers=extra_headers,
         )
         self.conversation = []
         system_instruction = self.model_config.get("system_instruction")


### PR DESCRIPTION
## Summary

This PR adds support for custom HTTP headers in Sorcar CLI, enabling users to connect to custom API endpoints that require authentication headers other than standard API keys (e.g., `X-Auth-Token`).

## Changes

### 1. CLI Option Addition (`src/kiss/agents/sorcar/cli_helpers.py`)
- Added new `--header` CLI argument that can be used multiple times
- Headers are parsed in `Key:Value` format
- Headers are passed to the model configuration as `extra_headers`

### 2. Model Support (`src/kiss/core/models/openai_compatible_model.py`)
- Modified `OpenAICompatibleModel` to read `extra_headers` from model config
- Headers are passed to the OpenAI client via `default_headers` parameter

## Usage Example

```bash
sorcar -e http://custom-endpoint.com/api/v2/ -m GLM-4.7 -t "your task" \
  --header "X-Auth-Token:your-token-here" \
  --header "X-Custom-Header:value"
```

## Motivation

Some custom API endpoints (like private InferHub) require authentication via custom headers (`X-Auth-Token`) rather than standard `Authorization` Bearer tokens. This change allows Sorcar to work with such endpoints.

## Testing

- Manually tested with Huawei InferHub endpoint using `X-Auth-Token` header
- Verified that custom headers are properly passed to the OpenAI client

## Files Changed

- `src/kiss/agents/sorcar/cli_helpers.py`
- `src/kiss/core/models/openai_compatible_model.py`