### PR TITLE
Fix KISS Sorcar daemon startup

### DIFF
--- a/src/kiss/agents/vscode/src/DependencyInstaller.ts
+++ b/src/kiss/agents/vscode/src/DependencyInstaller.ts
@@ -864,14 +864,7 @@ function restartKissWebDaemon(kissProjectPath: string): void {
   } catch {
     /* missing or unreadable — treat as mismatch */
   }
-  const daemonAlive = (() => {
-    try {
-      execSync('lsof -i :8787 -t', {stdio: 'ignore', timeout: 2000});
-      return true;
-    } catch {
-      return false;
-    }
-  })();
+  const daemonAlive = isDaemonRunning();
   if (currentFp && currentFp === savedFp && daemonAlive) {
     log(
       `kiss-web fingerprint unchanged (${currentFp.slice(0, 8)}) and ` +
@@ -975,6 +968,20 @@ function restartKissWebDaemon(kissProjectPath: string): void {
           stdio: 'ignore',
           timeout: 5000,
         });
+      }
+      try {
+        execFileSync(
+          'launchctl',
+          ['kickstart', '-k', `gui/${uid}/${plistLabel}`],
+          {
+            stdio: 'ignore',
+            timeout: 5000,
+          },
+        );
+      } catch (err) {
+        log(
+          `Failed to kickstart kiss-web daemon (macOS): ${err instanceof Error ? err.message : err}`,
+        );
       }
       log(`kiss-web macOS LaunchAgent restarted: ${plistFile}`);
     } catch (err) {
@@ -1323,8 +1330,9 @@ function playwrightBrowsersPath(): string {
 }
 
 /**
- * Check if the kiss-web daemon is running by probing port 8787.
- * Returns true if port 8787 has a listener (macOS/Linux only).
+ * Check if the kiss-web daemon is running by probing its TCP listener
+ * and the local Unix-domain socket used by the VS Code extension.
+ * Returns true only when both are present (macOS/Linux only).
  * On Windows the daemon is not supported, so always returns false.
  *
  * The probe is retried up to 3 times with 300 ms gaps before
@@ -1339,7 +1347,9 @@ function isDaemonRunning(): boolean {
   for (let attempt = 0; attempt < 3; attempt++) {
     try {
       execSync('lsof -i :8787 -t', {stdio: 'ignore', timeout: 3000});
-      return true;
+      if (fs.existsSync(path.join(LOG_DIR, 'sorcar.sock'))) {
+        return true;
+      }
     } catch {
       // not listening yet; fall through to retry
     }

--- a/src/kiss/tests/agents/vscode/test_build_extension_daemon_restart.py
+++ b/src/kiss/tests/agents/vscode/test_build_extension_daemon_restart.py
@@ -85,3 +85,20 @@ def test_build_script_force_kills_survivors() -> None:
         "build-extension.sh should force-kill (kill -9) survivors after "
         "the graceful-shutdown poll loop."
     )
+
+
+def test_dependency_installer_kickstarts_macos_launchagent() -> None:
+    """Loading the plist is not enough; activation must force-start it."""
+    src = DEP_INSTALLER.read_text(encoding="utf-8")
+    assert "'kickstart', '-k'" in src, (
+        "DependencyInstaller.ts must kickstart the macOS LaunchAgent after "
+        "bootstrap/load so kiss-web actually starts."
+    )
+
+
+def test_dependency_installer_health_requires_uds_socket() -> None:
+    """The VS Code extension uses ~/.kiss/sorcar.sock, not only port 8787."""
+    src = DEP_INSTALLER.read_text(encoding="utf-8")
+    assert "path.join(LOG_DIR, 'sorcar.sock')" in src, (
+        "Daemon health must require the UDS socket used by AgentClient."
+    )


### PR DESCRIPTION
## Summary
- force-start the macOS kiss-web LaunchAgent after bootstrap/load
- require the VS Code Unix socket in daemon health checks, not only port 8787
- add regression assertions for both startup requirements

## Verification
- npm run compile
- env PYTHONPATH=/Users/dash/kiss_ai/src /Users/dash/.vscode/extensions/ksenxx.kiss-sorcar-2026.6.1/kiss_project/.venv/bin/python -m pytest /Users/dash/kiss_ai/src/kiss/tests/agents/vscode/test_build_extension_daemon_restart.py
- verified in VS Code that the KISS Sorcar model picker shows models after reload