### PR TITLE
fix: capture Claude Code CLI usage data after early stop for tool_calls

### DIFF
--- a/src/kiss/core/models/claude_code_model.py
+++ b/src/kiss/core/models/claude_code_model.py
@@ -453,6 +453,31 @@ class ClaudeCodeModel(Model):
             content = content[:last_tc_end]
             self._stopped_for_tool_calls = True
 
+        # When we stopped early for tool_calls, continue reading the
+        # stream to capture the "result" event which carries usage data
+        # (input/output/cache token counts).  The "result" event always
+        # arrives AFTER all content blocks, so it was skipped by the
+        # early break above.  Without this, every agentic Claude Code
+        # call reports 0 tokens / $0 cost.
+        if self._stopped_for_tool_calls and not result_json:
+            for line in lines:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                etype = event.get("type")
+                if etype == "stream_event":
+                    event = event.get("event", {})
+                    etype = event.get("type")
+
+                if etype == "result":
+                    result_json = event
+                    break
+
         self._last_thinking_content = thinking_content
         self._pre_result_content = pre_result_content
         return content, result_json

--- a/src/kiss/tests/core/models/test_cc_early_stop_tool_calls.py
+++ b/src/kiss/tests/core/models/test_cc_early_stop_tool_calls.py
@@ -94,6 +94,28 @@ def _run_with_events(
     return function_calls, content, m
 
 
+def _run_with_events_and_response(
+    events: list[dict[str, Any]],
+    function_map: dict[str, Any] | None = None,
+) -> tuple[list[dict[str, Any]], str, dict[str, Any], ClaudeCodeModel]:
+    """Same as _run_with_events but also returns the raw response dict."""
+    m = ClaudeCodeModel("cc/opus")
+    m.initialize("test")
+    if function_map is None:
+        function_map = {
+            "Bash": lambda command, **kw: "ok",
+            "go_to_url": lambda url: "page content",
+        }
+    fake_popen = _build_fake_popen_class(events)
+    original_popen = subprocess.Popen
+    subprocess.Popen = fake_popen  # type: ignore[assignment,misc]
+    try:
+        function_calls, content, response = m.generate_and_process_with_tools(function_map)
+    finally:
+        subprocess.Popen = original_popen  # type: ignore[assignment,misc]
+    return function_calls, content, response, m
+
+
 class TestFindConsecutiveToolCallsEnd:
     """Unit tests for _find_consecutive_tool_calls_end helper."""
 
@@ -385,3 +407,85 @@ class TestEarlyStopOnToolCalls:
         names = {fc["name"] for fc in function_calls}
         assert "Bash" in names
         assert "go_to_url" in names
+
+    def test_usage_captured_after_early_stop(self) -> None:
+        """After early stop for tool_calls, usage data from result event is
+        captured so cost is not reported as $0."""
+        tool_json = json.dumps(
+            {"tool_calls": [{"name": "Bash", "arguments": {"command": "ls"}}]}
+        )
+        events = [
+            {"type": "stream_event", "event": {
+                "type": "content_block_start",
+                "content_block": {"type": "text", "text": ""},
+            }},
+            {"type": "stream_event", "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": tool_json},
+            }},
+            {"type": "stream_event", "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "\n\n(no output)\n"},
+            }},
+            {"type": "stream_event", "event": {"type": "content_block_stop"}},
+            {"type": "result", "result": tool_json + "\n\n(no output)",
+             "usage": {"input_tokens": 1234, "output_tokens": 56,
+                       "cache_read_input_tokens": 0}},
+        ]
+
+        function_calls, content, response, m = _run_with_events_and_response(events)
+
+        assert m._stopped_for_tool_calls is True
+        assert len(function_calls) == 1
+        assert isinstance(response, dict)
+        usage = response.get("usage", {})
+        assert usage.get("input_tokens") == 1234
+        assert usage.get("output_tokens") == 56
+
+    def test_usage_captured_with_simulated_agentic_loop(self) -> None:
+        """Same as test_simulated_agentic_loop_halted but includes the
+        result event with usage after the hallucinated content."""
+        first_tool = json.dumps(
+            {"tool_calls": [{"name": "Bash", "arguments": {
+                "command": "mkdir -p /tmp && echo 'hello'",
+            }}]}
+        )
+        hallucinated = (
+            '\n\n```\n(no output)\n```\n\n'
+            + json.dumps({"tool_calls": [{"name": "go_to_url", "arguments": {
+                "url": "https://x.com"
+            }}]})
+        )
+        events = [
+            {"type": "stream_event", "event": {
+                "type": "content_block_start",
+                "content_block": {"type": "text", "text": ""},
+            }},
+            {"type": "stream_event", "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta",
+                          "text": "I'll help.\n\n" + first_tool},
+            }},
+            {"type": "stream_event", "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": hallucinated},
+            }},
+            {"type": "stream_event", "event": {"type": "content_block_stop"}},
+            {"type": "result", "result": "...",
+             "usage": {"input_tokens": 5000, "output_tokens": 1200,
+                       "cache_read_input_tokens": 200,
+                       "cache_creation": {"ephemeral_5m_input_tokens": 300,
+                                          "ephemeral_1h_input_tokens": 0}}},
+        ]
+
+        function_calls, content, response, m = _run_with_events_and_response(events)
+
+        assert m._stopped_for_tool_calls is True
+        assert len(function_calls) == 1
+        assert function_calls[0]["name"] == "Bash"
+        usage = response.get("usage", {})
+        assert usage.get("input_tokens") == 5000
+        assert usage.get("output_tokens") == 1200
+        assert usage.get("cache_read_input_tokens") == 200
+        cache_creation = usage.get("cache_creation", {})
+        assert cache_creation.get("ephemeral_5m_input_tokens") == 300

--- a/src/kiss/tests/core/models/test_cc_usage_in_agentic_loop.py
+++ b/src/kiss/tests/core/models/test_cc_usage_in_agentic_loop.py
@@ -1,0 +1,200 @@
+# Author: Koushik Sen (ksen@berkeley.edu)
+# Contributors:
+# Koushik Sen (ksen@berkeley.edu)
+# add your name here
+"""Integration test: Claude Code CLI agentic calls report correct costs.
+
+When the streaming parser stops early because tool_calls were detected,
+the "result" event (which carries usage: input/output/cache token counts)
+must still be captured.  Otherwise ``extract_input_output_token_counts``
+returns all zeros and ``calculate_cost`` reports $0 for every agentic
+step, causing the budget / dashboard to massively undercount real API
+spend (issue #34).
+"""
+
+import json
+import subprocess
+from typing import Any
+
+from kiss.core.models.claude_code_model import ClaudeCodeModel
+from kiss.core.models.model_info import calculate_cost
+
+
+class _FakeStdin:
+    def write(self, s: str) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class _FakeStdout:
+    def __init__(self, data: str) -> None:
+        self._lines = data.splitlines(keepends=True)
+        self._pos = 0
+
+    def __iter__(self) -> "_FakeStdout":
+        return self
+
+    def __next__(self) -> str:
+        if self._pos >= len(self._lines):
+            raise StopIteration
+        line = self._lines[self._pos]
+        self._pos += 1
+        return line
+
+    def read(self) -> str:
+        rest = "".join(self._lines[self._pos:])
+        self._pos = len(self._lines)
+        return rest
+
+
+def _build_fake_popen_class(events: list[dict[str, Any]]) -> type:
+    stream_data = "\n".join(json.dumps(e) for e in events) + "\n"
+
+    class FakePopen:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.returncode = 0
+            self.stdin = _FakeStdin()
+            self.stdout = _FakeStdout(stream_data)
+            self.stderr = _FakeStdout("")
+            self._terminated = False
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+        def poll(self) -> int | None:
+            return 0 if self._terminated else None
+
+        def terminate(self) -> None:
+            self._terminated = True
+
+        def kill(self) -> None:
+            self._terminated = True
+
+    return FakePopen
+
+
+def _run_with_events(
+    events: list[dict[str, Any]],
+    function_map: dict[str, Any] | None = None,
+) -> tuple[list[dict[str, Any]], str, dict[str, Any], ClaudeCodeModel]:
+    m = ClaudeCodeModel("cc/opus")
+    m.initialize("test")
+    if function_map is None:
+        function_map = {
+            "Bash": lambda command, **kw: "ok",
+            "go_to_url": lambda url: "page content",
+        }
+    fake_popen = _build_fake_popen_class(events)
+    original_popen = subprocess.Popen
+    subprocess.Popen = fake_popen  # type: ignore[assignment,misc]
+    try:
+        function_calls, content, response = m.generate_and_process_with_tools(function_map)
+    finally:
+        subprocess.Popen = original_popen  # type: ignore[assignment,misc]
+    return function_calls, content, response, m
+
+
+class TestAgenticCost:
+    def test_early_stop_reports_correct_cost(self) -> None:
+        tool_json = json.dumps(
+            {"tool_calls": [{"name": "Bash", "arguments": {"command": "ls"}}]}
+        )
+        events = [
+            {"type": "stream_event", "event": {
+                "type": "content_block_start",
+                "content_block": {"type": "text", "text": ""},
+            }},
+            {"type": "stream_event", "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": tool_json},
+            }},
+            {"type": "stream_event", "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "\n\n(no output)\n"},
+            }},
+            {"type": "stream_event", "event": {"type": "content_block_stop"}},
+            {"type": "result", "result": tool_json + "\n\n(no output)",
+             "usage": {"input_tokens": 10000, "output_tokens": 500,
+                       "cache_read_input_tokens": 0}},
+        ]
+
+        _, _, response, m = _run_with_events(events)
+
+        assert m._stopped_for_tool_calls is True
+
+        counts = m.extract_input_output_token_counts_from_response(response)
+        input_t, output_t, cache_read, cache_write_5m, cache_write_1h = counts
+
+        assert input_t == 10000
+        assert output_t == 500
+
+        # calculate_cost must not raise KISSError — cc/opus pricing is
+        # $0/$0 (billed via subscription), so cost == 0 is expected.
+        calculate_cost(
+            m.model_name,
+            input_t,
+            output_t,
+            cache_read,
+            cache_write_5m,
+            cache_write_1h,
+        )
+
+    def test_agentic_loop_cost_with_cache(self) -> None:
+        first_tool = json.dumps(
+            {"tool_calls": [{"name": "Bash", "arguments": {
+                "command": "mkdir -p /tmp && echo 'hello'",
+            }}]}
+        )
+        hallucinated = (
+            '\n\n```\n(no output)\n```\n\n'
+            + json.dumps({"tool_calls": [{"name": "go_to_url", "arguments": {
+                "url": "https://x.com"
+            }}]})
+        )
+        events = [
+            {"type": "stream_event", "event": {
+                "type": "content_block_start",
+                "content_block": {"type": "text", "text": ""},
+            }},
+            {"type": "stream_event", "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta",
+                          "text": "I'll help.\n\n" + first_tool},
+            }},
+            {"type": "stream_event", "event": {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": hallucinated},
+            }},
+            {"type": "stream_event", "event": {"type": "content_block_stop"}},
+            {"type": "result", "result": "...",
+             "usage": {"input_tokens": 50000, "output_tokens": 2000,
+                       "cache_read_input_tokens": 10000,
+                       "cache_creation": {"ephemeral_5m_input_tokens": 5000,
+                                          "ephemeral_1h_input_tokens": 2000}}},
+        ]
+
+        _, _, response, m = _run_with_events(events)
+
+        assert m._stopped_for_tool_calls is True
+
+        counts = m.extract_input_output_token_counts_from_response(response)
+        input_t, output_t, cache_read, cache_write_5m, cache_write_1h = counts
+
+        assert input_t == 50000
+        assert output_t == 2000
+        assert cache_read == 10000
+        assert cache_write_5m == 5000
+        assert cache_write_1h == 2000
+
+        # calculate_cost must not raise KISSError — cc/opus pricing is
+        # $0/$0 (billed via subscription), so cost == 0 is expected.
+        calculate_cost(
+            m.model_name,
+            input_t,
+            output_t,
+            cache_read,
+            cache_write_5m,
+            cache_write_1h,
+        )


### PR DESCRIPTION
> PR developed and drafted with the assistance of opencode + DeepSeek V4 Pro. All code logic, test cases, and texts have been manually reviewed and verified.

## Summary

When the Claude Code CLI streaming parser detects `tool_calls` and stops
early (to prevent hallucinated tool results), the `"result"` event — which
carries `usage` data (input/output/cache token counts) — was skipped.
This caused every agentic `cc/*` step to report 0 tokens and $0 cost,
massively undercounting real API spend. Fixes #34.

## Root Cause

Anthropic's Claude CLI with `--output-format stream-json` always emits
the `"result"` event **after** all content blocks.  The
`_parse_stream_events()` method breaks out of the main loop early when
tool calls are detected, so the result event was never read from the
stream.

## Changes

1. `src/kiss/core/models/claude_code_model.py` — Added a post-loop
   consumer (lines 462–479) that continues reading the stream after
   early stop to capture the `"result"` event with usage data.  Guarded
   by `_stopped_for_tool_calls and not result_json`.

2. `src/kiss/tests/core/models/test_cc_early_stop_tool_calls.py` — Added
   `_run_with_events_and_response()` helper (returns the raw response
   dict) plus 2 new tests:
   - `test_usage_captured_after_early_stop` — usage from result event
     is present after early stop
   - `test_usage_captured_with_simulated_agentic_loop` — usage + cache
     data captured in a hallucinated agentic loop scenario

3. `src/kiss/tests/core/models/test_cc_usage_in_agentic_loop.py` (new) —
   Integration tests verifying:
   - `extract_input_output_token_counts_from_response` returns correct
     token counts after early stop

## Testing

uv run pytest src/kiss/tests/core/models/test_cc_early_stop_tool_calls.py \
               src/kiss/tests/core/models/test_cc_usage_in_agentic_loop.py \
               src/kiss/tests/core/models/test_cc_pre_result_content_fallback.py \
               -v --no-cov

Result: **32/32 passed** (regression-free across all CC model tests).

## Files Changed

- `src/kiss/core/models/claude_code_model.py`
- `src/kiss/tests/core/models/test_cc_early_stop_tool_calls.py`
- `src/kiss/tests/core/models/test_cc_usage_in_agentic_loop.py`