### PR TITLE
fix: Windows compatibility fixes for kiss-web (AI-generated, reviewed…

### DIFF
--- a/src/kiss/agents/vscode/vscode_config.py
+++ b/src/kiss/agents/vscode/vscode_config.py
@@ -10,9 +10,12 @@ API key injection into shell RC files and the running environment.
 
 from __future__ import annotations
 
-import fcntl
 import json
 import logging
+import sys
+
+if sys.platform != "win32":
+    import fcntl  # pragma: no cover
 import os
 import shlex
 import shutil
@@ -194,8 +197,11 @@ def save_config(data: dict[str, Any]) -> None:
     # service daemon persists ``last_model``) — without it, two daemons
     # that each read the same old file and replace it would drop one
     # another's keys.
-    with _config_lock, open(CONFIG_DIR / ".config.lock", "w") as lock_file:
-        fcntl.flock(lock_file, fcntl.LOCK_EX)
+    with _config_lock:
+        lock_file = None
+        if sys.platform != "win32":
+            lock_file = open(CONFIG_DIR / ".config.lock", "w")
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
         try:
             existing: dict[str, Any] = {}
             if CONFIG_PATH.exists():
@@ -219,7 +225,9 @@ def save_config(data: dict[str, Any]) -> None:
                 os.close(fd)
             os.replace(tmp, CONFIG_PATH)
         finally:
-            fcntl.flock(lock_file, fcntl.LOCK_UN)
+            if lock_file is not None:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+                lock_file.close()
 
 
 def _get_user_shell() -> str:

--- a/src/kiss/agents/vscode/web_server.py
+++ b/src/kiss/agents/vscode/web_server.py
@@ -5364,11 +5364,14 @@ class RemoteAccessServer:
         it silently no-ops when not on the main thread or when the
         signal is unsupported on the current platform.
         """
-        for sig in (signal.SIGTERM, signal.SIGHUP):
+        for sig_name in ("SIGTERM", "SIGHUP"):
+            sig = getattr(signal, sig_name, None)
+            if sig is None:
+                continue  # unsupported on this platform (e.g. SIGHUP on Windows)
             try:
                 signal.signal(sig, self._handle_shutdown_signal)
             except (OSError, ValueError):
-                pass  # e.g. not main thread, or unsupported on this OS
+                pass  # e.g. not main thread
 
     def start(self) -> None:
         """Start the server (blocks until interrupted).

--- a/src/kiss/core/base.py
+++ b/src/kiss/core/base.py
@@ -32,7 +32,7 @@ def _str_presenter(dumper: yaml.Dumper, data: str) -> ScalarNode:
 yaml.add_representer(str, _str_presenter)
 
 _kiss_pkg_dir = Path(__file__).parent.parent
-SYSTEM_PROMPT = (_kiss_pkg_dir / "SYSTEM.md").read_text()
+SYSTEM_PROMPT = (_kiss_pkg_dir / "SYSTEM.md").read_text(encoding="utf-8")
 
 if sys.platform == "win32":  # pragma: no branch
     if shutil.which("bash"):  # pragma: no branch


### PR DESCRIPTION
… by non-programmer)

If this commit does not follow project conventions, please directly Ctrl+V the changes to your develop environment.

Three Unix-only assumptions fixed: - base.py: Path.read_text() defaults to GBK on Windows, explicit utf-8 - vscode_config.py: fcntl is Unix-only, conditional import + guard - web_server.py: signal.SIGHUP is Unix-only, use getattr() fallback

Authored by: AI (Claude) Reviewed by: non-programmer human