### PR TITLE
feat: support ANTHROPIC_AUTH_TOKEN and ANTHROPIC_BASE_URL for Claude models

### DIFF
--- a/src/kiss/core/config.py
+++ b/src/kiss/core/config.py
@@ -116,6 +116,22 @@ class Config(BaseModel):
         default_factory=lambda: os.getenv("ANTHROPIC_API_KEY", ""),
         description="Anthropic API key (can also be set via ANTHROPIC_API_KEY env var)",
     )
+    ANTHROPIC_AUTH_TOKEN: str = Field(
+        default_factory=lambda: os.getenv("ANTHROPIC_AUTH_TOKEN", ""),
+        description=(
+            "Anthropic auth token sent as an Authorization: Bearer header "
+            "(can also be set via ANTHROPIC_AUTH_TOKEN env var). Used by "
+            "proxies/gateways instead of ANTHROPIC_API_KEY."
+        ),
+    )
+    ANTHROPIC_BASE_URL: str = Field(
+        default_factory=lambda: os.getenv("ANTHROPIC_BASE_URL", ""),
+        description=(
+            "Custom Anthropic API base URL (can also be set via "
+            "ANTHROPIC_BASE_URL env var). Used to route requests through a "
+            "proxy or gateway."
+        ),
+    )
     TOGETHER_API_KEY: str = Field(
         default_factory=lambda: os.getenv("TOGETHER_API_KEY", ""),
         description="Together API key (can also be set via TOGETHER_API_KEY env var)",

--- a/src/kiss/core/models/anthropic_model.py
+++ b/src/kiss/core/models/anthropic_model.py
@@ -65,12 +65,17 @@ class AnthropicModel(Model):
         model_config: dict[str, Any] | None = None,
         token_callback: TokenCallback | None = None,
         thinking_callback: ThinkingCallback | None = None,
+        auth_token: str = "",
+        base_url: str = "",
     ):
         """Initialize an AnthropicModel instance.
 
         Args:
             model_name: The name of the Claude model to use.
             api_key: The Anthropic API key for authentication.
+            auth_token: Optional bearer token sent via the ``Authorization``
+                header instead of ``x-api-key`` (e.g. for a proxy/gateway).
+            base_url: Optional custom API base URL (e.g. for a proxy/gateway).
             model_config: Optional dictionary of model configuration parameters.
             token_callback: Optional callback invoked with each streamed text token.
             thinking_callback: Optional callback invoked with ``True`` when a
@@ -83,6 +88,8 @@ class AnthropicModel(Model):
             thinking_callback=thinking_callback,
         )
         self.api_key = api_key
+        self.auth_token = auth_token
+        self.base_url = base_url
 
     def initialize(self, prompt: str, attachments: list[Attachment] | None = None) -> None:
         """Initializes the conversation with an initial user prompt.
@@ -95,7 +102,16 @@ class AnthropicModel(Model):
                 is available; otherwise they are skipped with a warning.  Video
                 attachments are always skipped.
         """
-        self.client = Anthropic(api_key=self.api_key)
+        client_kwargs: dict[str, Any] = {}
+        # Prefer an explicit auth token (Authorization: Bearer) when provided;
+        # otherwise fall back to the x-api-key based api_key.
+        if self.auth_token:
+            client_kwargs["auth_token"] = self.auth_token
+        else:
+            client_kwargs["api_key"] = self.api_key
+        if self.base_url:
+            client_kwargs["base_url"] = self.base_url
+        self.client = Anthropic(**client_kwargs)
         content: str | list[dict[str, Any]] = prompt
         if attachments:
             blocks: list[dict[str, Any]] = []

--- a/src/kiss/core/models/model_info.py
+++ b/src/kiss/core/models/model_info.py
@@ -560,6 +560,8 @@ def model(
         return AnthropicModel(  # type: ignore[no-any-return]
             model_name=model_name,
             api_key=keys.ANTHROPIC_API_KEY,
+            auth_token=getattr(keys, "ANTHROPIC_AUTH_TOKEN", ""),
+            base_url=getattr(keys, "ANTHROPIC_BASE_URL", ""),
             model_config=model_config,
             token_callback=token_callback,
             thinking_callback=thinking_callback,
@@ -620,7 +622,7 @@ def get_available_models() -> list[str]:
     keys = config_module.DEFAULT_CONFIG
     prefix_to_key = {
         "openrouter/": keys.OPENROUTER_API_KEY,
-        "claude-": keys.ANTHROPIC_API_KEY,
+        "claude-": keys.ANTHROPIC_API_KEY or getattr(keys, "ANTHROPIC_AUTH_TOKEN", ""),
         "gemini-": keys.GEMINI_API_KEY,
         "glm-": keys.ZAI_API_KEY,
         "kimi-": keys.MOONSHOT_API_KEY,
@@ -717,7 +719,7 @@ def get_generation_model_listing() -> list[tuple[str, str, bool]]:
 
     keys = config_module.DEFAULT_CONFIG
     provider_configured = {
-        "Anthropic": bool(keys.ANTHROPIC_API_KEY),
+        "Anthropic": bool(keys.ANTHROPIC_API_KEY or getattr(keys, "ANTHROPIC_AUTH_TOKEN", "")),
         "OpenAI": bool(keys.OPENAI_API_KEY),
         "Gemini": bool(keys.GEMINI_API_KEY),
         "OpenRouter": bool(keys.OPENROUTER_API_KEY),
@@ -824,7 +826,7 @@ def get_default_model() -> str:
     from kiss.core.models.codex_model import find_codex_executable
 
     keys = config_module.DEFAULT_CONFIG
-    if keys.ANTHROPIC_API_KEY:
+    if keys.ANTHROPIC_API_KEY or getattr(keys, "ANTHROPIC_AUTH_TOKEN", ""):
         return "claude-opus-4-7"
     if keys.OPENAI_API_KEY:
         return "gpt-5.5"

--- a/src/kiss/tests/core/test_uncovered_branches.py
+++ b/src/kiss/tests/core/test_uncovered_branches.py
@@ -228,6 +228,7 @@ class TestGetAvailableModels:
 
         env_keys = [
             "ANTHROPIC_API_KEY",
+            "ANTHROPIC_AUTH_TOKEN",
             "OPENROUTER_API_KEY",
             "GEMINI_API_KEY",
             "OPENAI_API_KEY",


### PR DESCRIPTION
## Summary

Adds support for the standard Anthropic SDK environment variables so Claude (`claude-*`) requests can be routed through a proxy/gateway:

- **`ANTHROPIC_AUTH_TOKEN`** — sent as an `Authorization: Bearer` header instead of `x-api-key` (preferred over `ANTHROPIC_API_KEY` when set).
- **`ANTHROPIC_BASE_URL`** — custom API base URL.

These are **not new/invented names** — they are the established Anthropic conventions. Both the official Anthropic Python SDK (`Anthropic(auth_token=..., base_url=...)`) and Claude Code itself read `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_BASE_URL` from the environment for exactly this purpose (routing through a gateway/proxy with bearer-token auth). This change just makes the KISS framework honor the same variables.

Both are added as `Config` fields and threaded into `AnthropicModel`, which now builds the `Anthropic` client with `auth_token`/`base_url` accordingly.

Model selection (`get_default_model`), availability (`get_available_models`), and the provider listing (`get_generation_model_listing`) now treat an auth token as sufficient Anthropic credentials, so `claude-*` models are selectable when only `ANTHROPIC_AUTH_TOKEN` is set (no API key).

## Motivation

Without this, setting `ANTHROPIC_AUTH_TOKEN` + `ANTHROPIC_BASE_URL` had no effect: the client was always built with `api_key` only, and `claude-*` models were gated on `ANTHROPIC_API_KEY`, so gateway/proxy users could not use Claude models — even though these are the same env vars they already use with Claude Code and the Anthropic SDK.

## Testing

- Verified the client uses `auth_token`/`base_url` when provided and falls back to `api_key` otherwise.
- Confirmed a real request succeeds against a custom `ANTHROPIC_BASE_URL` gateway.
- `test_get_default_model_priority` updated to clear/restore `ANTHROPIC_AUTH_TOKEN`.
- Affected test suites pass (`anthropic`, `default_model`, `model_info`, `available_models`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)